### PR TITLE
Normalize CSS class and icon name constants

### DIFF
--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -154,15 +154,6 @@ const string
 	PROP_STRIP     {"p.sd"},
 	PROP_STRIP_UID {"p.sid"}, // strip descriptor UID
 
-/// CSS-related constants
-	COLOR_PIN      {"pinSingle"},
-	COLOR_SOLENOID {"pinSolenoid"},
-	COLOR_RED      {"pinRed"},
-	COLOR_GREEN    {"pinGreen"},
-	COLOR_BLUE     {"pinBlue"},
-	COLOR_MULTIPLE {"pinMulti"},
-	PIN_LABEL      {"pinLabel"},
-	CONNECTOR_BOX  {"connectorBox"},
 	NO_COLOR       {emptyString},
 
 /// Restrictor configuration keys.
@@ -238,15 +229,57 @@ const string
 
 } // namespace
 
-// CSS classes
-#define BOX_BACKGROUND_DELETE "BoxBackgroundDelete"
-#define BOX_BACKGROUND_EDIT   "BoxBackgroundEdit"
-#define BOX_BACKGROUND_COPY   "BoxBackgroundCopy"
+// CSS classes — CSS_SUBJECT_INTENTION
 
-// Project Icons
-#define ICON_TRASH "user-trash-symbolic"
-#define ICON_EDIT  "emblem-system-symbolic"
-#define ICON_COPY  "edit-copy-symbolic"
+// Box backgrounds
+#define CSS_BOX_BACKGROUND_DELETE     "BoxBackgroundDelete"
+#define CSS_BOX_BACKGROUND_EDIT       "BoxBackgroundEdit"
+#define CSS_BOX_BACKGROUND_COPY       "BoxBackgroundCopy"
+#define CSS_BACKGROUND_RED            "backgroundRed"
+#define CSS_BACKGROUND_GREEN          "backgroundGreen"
+
+// Breadcrumb
+#define CSS_BREADCRUMB_BUTTON         "BreadcrumbButton"
+#define CSS_BREADCRUMB_SEPARATOR      "BreadcrumbSeparator"
+#define CSS_BREADCRUMB_CURRENT        "BreadcrumbCurrent"
+
+// Color picker
+#define CSS_COLOR_BUTTON              "ColorButton"
+#define CSS_COLOR_PIN                 "pinSingle"
+#define CSS_COLOR_SOLENOID            "pinSolenoid"
+#define CSS_COLOR_RED                 "pinRed"
+#define CSS_COLOR_GREEN               "pinGreen"
+#define CSS_COLOR_BLUE                "pinBlue"
+#define CSS_COLOR_MULTIPLE            "pinMulti"
+
+// Pin / connector
+#define CSS_PIN_LABEL                 "pinLabel"
+#define CSS_BOX_CONNECTOR             "connectorBox"
+
+// Form / layout
+#define CSS_FORM_CONTAINER            "formContainer"
+#define CSS_SYSTEM                    "system"
+
+// Storage box buttons
+#define CSS_BOX_BUTTON                "BoxButton"
+#define CSS_DEVICE_BOX_BUTTON         "DeviceBoxButton"
+#define CSS_DIRECTORY_BOX_BUTTON      "DirectoryBoxButton"
+#define CSS_ELEMENT_BOX_BUTTON        "ElementBoxButton"
+#define CSS_GROUP_BOX_BUTTON          "GroupBoxButton"
+#define CSS_INPUT_BOX_BUTTON          "InputBoxButton"
+#define CSS_INPUT_MAP_BOX_BUTTON      "InputMapBoxButton"
+#define CSS_INPUT_SOURCE_BOX_BUTTON   "InputSourceBoxButton"
+#define CSS_LINK_BOX_BUTTON           "LinkBoxButton"
+#define CSS_PROCESS_BOX_BUTTON        "ProcessBoxButton"
+#define CSS_PROFILE_BOX_BUTTON        "ProfileBoxButton"
+#define CSS_RESTRICTOR_BOX_BUTTON     "RestrictorBoxButton"
+#define CSS_RESTRICTOR_MAP_BOX_BUTTON "RestrictorMapBoxButton"
+
+// Icons — all symbolic
+#define ICON_COPY   "edit-copy-symbolic"
+#define ICON_DELETE "edit-delete-symbolic"
+#define ICON_EDIT   "emblem-system-symbolic"
+#define ICON_TRASH  "user-trash-symbolic"
 
 
 using namespace Constants;

--- a/src/Ui/DataDialogs/DialogElement.cpp
+++ b/src/Ui/DataDialogs/DialogElement.cpp
@@ -702,14 +702,14 @@ void DialogElement::drawPins() noexcept {
 	labels.reserve(numberOfPins);
 	for (uint16_t c = 1; c <= numberOfPins; ++c) {
 		Gtk::Label* label(Gtk::make_managed<Gtk::Label>(std::to_string(c)));
-		label->get_style_context()->add_class(PIN_LABEL);
+		label->get_style_context()->add_class(CSS_PIN_LABEL);
 		auto& pinUsage(pinsUsage[c - 1]);
 		string labelTxt("Connector " + std::to_string(c));
 		if (pinUsage.first.empty()) {
 			labelTxt += " is unused";
 		}
 		else {
-			labelTxt += string(" is used by element") + (pinUsage.first == COLOR_MULTIPLE ? "s " : " ");
+			labelTxt += string(" is used by element") + (pinUsage.first == CSS_COLOR_MULTIPLE ? "s " : " ");
 			label->get_style_context()->add_class(std::move(pinUsage.first));
 		}
 		label->set_tooltip_text(labelTxt + std::move(pinUsage.second));
@@ -734,7 +734,7 @@ void DialogElement::drawPinsRGB(vector<Gtk::Label*>& labels) noexcept {
 		Gtk::VBox* vboxConnector = Gtk::manage(new Gtk::VBox(true));
 		pinsBox->add(*vboxConnector);
 		vboxConnector->set_name("boxRGB_" + std::to_string(led));
-		vboxConnector->get_style_context()->add_class(CONNECTOR_BOX);
+		vboxConnector->get_style_context()->add_class(CSS_BOX_CONNECTOR);
 		vboxConnector->set_hexpand(false);
 		vboxConnector->set_vexpand(false);
 		vboxConnector->set_valign(Gtk::ALIGN_START);
@@ -753,7 +753,7 @@ void DialogElement::drawPinsRGB(vector<Gtk::Label*>& labels) noexcept {
 	// Create box for extra pins.
 	Gtk::VBox* vboxConnector = Gtk::manage(new Gtk::VBox(true));
 	pinsBox->add(*vboxConnector);
-	vboxConnector->get_style_context()->add_class(CONNECTOR_BOX);
+	vboxConnector->get_style_context()->add_class(CSS_BOX_CONNECTOR);
 	vboxConnector->set_hexpand(false);
 	vboxConnector->set_vexpand(false);
 	vboxConnector->set_valign(Gtk::ALIGN_START);
@@ -792,7 +792,7 @@ void DialogElement::findConnectorTypes(vector<std::pair<string, string>>& pinsUs
 		if (pair.first == color or pair.first == NO_COLOR)
 			pair.first = color;
 		else
-			pair.first = COLOR_MULTIPLE;
+			pair.first = CSS_COLOR_MULTIPLE;
 	};
 
 	std::function<void(
@@ -813,13 +813,13 @@ void DialogElement::findConnectorTypes(vector<std::pair<string, string>>& pinsUs
 				pair.second = pair.second + " - " + data->getValue(NAME);
 			switch (c) {
 			case 'R':
-				storePins(pair, COLOR_RED);
+				storePins(pair, CSS_COLOR_RED);
 				break;
 			case 'G':
-				storePins(pair, COLOR_GREEN);
+				storePins(pair, CSS_COLOR_GREEN);
 				break;
 			case 'B':
-				storePins(pair, COLOR_BLUE);
+				storePins(pair, CSS_COLOR_BLUE);
 			}
 		}
 	};
@@ -848,28 +848,28 @@ void DialogElement::findConnectorTypes(vector<std::pair<string, string>>& pinsUs
 		// Single.
 		else if (not data->getValue(PIN).empty()) {
 			const uint16_t index(std::stoi(data->getValue(PIN)) - 1);
-			storePins(pinsUsage[index], COLOR_PIN);
+			storePins(pinsUsage[index], CSS_COLOR_PIN);
 			pinsUsage[index].second = data->getValue(NAME);
 		}
 		// Solenoid.
 		else if (not data->getValue(SOLENOID).empty()) {
 			const uint16_t index(std::stoi(data->getValue(SOLENOID)) - 1);
-			storePins(pinsUsage[index], COLOR_SOLENOID);
+			storePins(pinsUsage[index], CSS_COLOR_SOLENOID);
 			pinsUsage[index].second = data->getValue(NAME);
 		}
 		// Scattered RGB
 		else {
 			// Red.
 			uint16_t index(std::stoi(data->getValue(RED_PIN)) - 1);
-			storePins(pinsUsage[index], COLOR_RED);
+			storePins(pinsUsage[index], CSS_COLOR_RED);
 			pinsUsage[index].second = data->getValue(NAME);
 			// Green.
 			index = std::stoi(data->getValue(GREEN_PIN)) - 1;
-			storePins(pinsUsage[index], COLOR_GREEN);
+			storePins(pinsUsage[index], CSS_COLOR_GREEN);
 			pinsUsage[index].second = data->getValue(NAME);
 			// Blue.
 			index = std::stoi(data->getValue(BLUE_PIN)) - 1;
-			storePins(pinsUsage[index], COLOR_BLUE);
+			storePins(pinsUsage[index], CSS_COLOR_BLUE);
 			pinsUsage[index].second = data->getValue(NAME);
 		}
 	}

--- a/src/Ui/DataDialogs/DialogForm.cpp
+++ b/src/Ui/DataDialogs/DialogForm.cpp
@@ -169,7 +169,7 @@ void DialogForm::createDeleteButton(
 	auto button(Gtk::make_managed<Gtk::Button>());
 	boxButton.pack_start(*button, Gtk::PACK_SHRINK);
 	button->set_image_from_icon_name(ICON_TRASH, Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class(BOX_BACKGROUND_DELETE);
+	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_DELETE);
 	button->set_tooltip_text("Delete " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&, askConfirmation]() {
 		if (askConfirmation) {
@@ -186,7 +186,7 @@ void DialogForm::createEditButton(Storage::BoxButton& boxButton) noexcept {
 	auto button(Gtk::make_managed<Gtk::Button>());
 	boxButton.pack_start(*button, Gtk::PACK_SHRINK);
 	button->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class(BOX_BACKGROUND_EDIT);
+	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_EDIT);
 	button->set_tooltip_text("Edit " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&]() {
 		onEditClicked(boxButton);
@@ -197,7 +197,7 @@ void DialogForm::createCloneButton(Storage::BoxButton& boxButton) noexcept {
 	auto button(Gtk::make_managed<Gtk::Button>());
 	boxButton.pack_start(*button, Gtk::PACK_SHRINK);
 	button->set_image_from_icon_name(ICON_COPY, Gtk::ICON_SIZE_BUTTON);
-	button->get_style_context()->add_class(BOX_BACKGROUND_COPY);
+	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_COPY);
 	button->set_tooltip_text("Clone " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&]() {
 		onCloneClicked(boxButton);

--- a/src/Ui/DataDialogs/DialogSelect.cpp
+++ b/src/Ui/DataDialogs/DialogSelect.cpp
@@ -191,7 +191,7 @@ void DialogSelect::populatePicker() noexcept {
 			auto flowChild{Gtk::make_managed<Gtk::FlowBoxChild>()};
 
 			if (data->getProperties().isSet(PROP_SYSTEM))
-				selection->get_style_context()->add_class("system");
+				selection->get_style_context()->add_class(CSS_SYSTEM);
 
 			selection->signal_clicked().connect([this, flowChild]() {
 				if (flowChild->is_selected())
@@ -217,7 +217,7 @@ void DialogSelect::addDisplayButtons(Storage::BoxButton& boxButton) noexcept {
 	if (not request->linkFields.empty()) {
 		auto btn{Gtk::make_managed<Gtk::Button>()};
 		boxButton.pack_start(*btn, Gtk::PACK_SHRINK);
-		btn->set_image_from_icon_name("emblem-system-symbolic", Gtk::ICON_SIZE_BUTTON);
+		btn->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
 		btn->set_tooltip_text("Edit");
 		btn->signal_clicked().connect([&boxButton, this]() {
 			DialogLinkEditor::getInstance()->open(
@@ -230,7 +230,7 @@ void DialogSelect::addDisplayButtons(Storage::BoxButton& boxButton) noexcept {
 	// DELETE its always present.
 	auto btn{Gtk::make_managed<Gtk::Button>()};
 	boxButton.pack_start(*btn, Gtk::PACK_SHRINK);
-	btn->set_image_from_icon_name("edit-delete", Gtk::ICON_SIZE_BUTTON);
+	btn->set_image_from_icon_name(ICON_DELETE, Gtk::ICON_SIZE_BUTTON);
 	btn->set_tooltip_text("Remove");
 	btn->signal_clicked().connect([&boxButton, this]() {
 		Defaults::markDirty();

--- a/src/Ui/DialogColors.cpp
+++ b/src/Ui/DialogColors.cpp
@@ -227,14 +227,14 @@ void DialogColors::createColorButton(Gtk::FlowBox* destination, const string& co
 	box->set_margin_bottom(2);
 	box->set_margin_left(2);
 	box->set_margin_right(2);
-	box->get_style_context()->add_class("ColorButton");
+	box->get_style_context()->add_class(CSS_COLOR_BUTTON);
 
 	auto l {Gtk::make_managed<Gtk::Label>(color)};
 	l->get_style_context()->add_class(color);
 
 	// Button delete.
 	auto b {Gtk::make_managed<Gtk::Button>()};
-	b->set_image_from_icon_name("edit-delete", Gtk::ICON_SIZE_BUTTON);
+	b->set_image_from_icon_name(ICON_DELETE, Gtk::ICON_SIZE_BUTTON);
 	b->signal_clicked().connect([box, destination]() {
 		Defaults::markDirty();
 		destination->remove(*box);

--- a/src/Ui/DialogImport.cpp
+++ b/src/Ui/DialogImport.cpp
@@ -45,9 +45,9 @@ DialogImport::DialogImport(const Types type, Gtk::Window* parent) :
 	filter->add_mime_type("application/xml");
 
 	// Set buttons.
-	add_button("_Cancel", Gtk::ResponseType::RESPONSE_CANCEL)->get_style_context()->add_class("backgroundRed");
+	add_button("_Cancel", Gtk::ResponseType::RESPONSE_CANCEL)->get_style_context()->add_class(CSS_BACKGROUND_RED);
 	btbOk = add_button("_Open",   Gtk::ResponseType::RESPONSE_OK);
-	btbOk->get_style_context()->add_class("backgroundGreen");
+	btbOk->get_style_context()->add_class(CSS_BACKGROUND_GREEN);
 	auto box = get_content_area();
 	switch (type) {
 	case Types::CONFIG:
@@ -74,7 +74,7 @@ void DialogImport::setConfigBox(Gtk::Box* box) {
 	box->add(*Gtk::make_managed<Gtk::Label>("Select what to import"));
 	auto hbox = Gtk::make_managed<Gtk::Box>(Gtk::Orientation::ORIENTATION_HORIZONTAL, 2);
 	box->add(*hbox);
-	hbox->get_style_context()->add_class("formContainer");
+	hbox->get_style_context()->add_class(CSS_FORM_CONTAINER);
 
 	Gtk::ToggleButton
 		* importConfig      = Gtk::make_managed<Gtk::ToggleButton>("Import Config"),

--- a/src/Ui/InputDirectoryNavigator.cpp
+++ b/src/Ui/InputDirectoryNavigator.cpp
@@ -113,12 +113,12 @@ void InputDirectoryNavigator::wireDialogs(Storage::DirectoryEntry* dir) noexcept
 		auto node = static_cast<Storage::DirectoryEntry*>(dir->getParent());
 		while (not node->isAtRoot()) {
 			auto btn{Gtk::make_managed<Gtk::Button>(node->getName())};
-			btn->get_style_context()->add_class("BreadcrumbButton");
+			btn->get_style_context()->add_class(CSS_BREADCRUMB_BUTTON);
 			btn->signal_clicked().connect([this, node]() {
 				enterDirectory(node);
 			});
 			auto sep{Gtk::make_managed<Gtk::Label>("/")};
-			sep->get_style_context()->add_class("BreadcrumbSeparator");
+			sep->get_style_context()->add_class(CSS_BREADCRUMB_SEPARATOR);
 
 			// Reorder so each ancestor goes to the front, keeping correct left-to-right order.
 			boxBreadcrumb->pack_start(*btn, Gtk::PACK_SHRINK);
@@ -131,12 +131,12 @@ void InputDirectoryNavigator::wireDialogs(Storage::DirectoryEntry* dir) noexcept
 
 		// Separator before the current (non-clickable) label.
 		auto sep{Gtk::make_managed<Gtk::Label>("/")};
-		sep->get_style_context()->add_class("BreadcrumbSeparator");
+		sep->get_style_context()->add_class(CSS_BREADCRUMB_SEPARATOR);
 		boxBreadcrumb->pack_end(*sep, Gtk::PACK_SHRINK);
 
 		// Current directory label at the end.
 		auto cur{Gtk::make_managed<Gtk::Label>(dir->getName())};
-		cur->get_style_context()->add_class("BreadcrumbCurrent");
+		cur->get_style_context()->add_class(CSS_BREADCRUMB_CURRENT);
 		boxBreadcrumb->pack_end(*cur, Gtk::PACK_SHRINK);
 	}
 

--- a/src/Ui/Storage/BoxButton.cpp
+++ b/src/Ui/Storage/BoxButton.cpp
@@ -45,7 +45,7 @@ BoxButton::BoxButton(Data* form) noexcept :
 	label->set_visible(true);
 	pack_start(*lbox, Gtk::PACK_EXPAND_WIDGET);
 
-	get_style_context()->add_class("BoxButton");
+	get_style_context()->add_class(CSS_BOX_BUTTON);
 	auto cssClass{form->getCssClass()};
 	if (not cssClass.empty())
 		get_style_context()->add_class(string(cssClass));

--- a/src/Ui/Storage/Device.hpp
+++ b/src/Ui/Storage/Device.hpp
@@ -42,7 +42,7 @@ public:
 	virtual ~Device() = default;
 
 	string_view getXmlTag()   const noexcept override { return "device"; }
-	string_view getCssClass() const noexcept override { return "DeviceBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_DEVICE_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 	string createUniqueId()   const noexcept override;
 

--- a/src/Ui/Storage/DirectoryEntry.hpp
+++ b/src/Ui/Storage/DirectoryEntry.hpp
@@ -50,7 +50,7 @@ public:
 	string createPrettyName() const noexcept override;
 	string createTooltip()    const noexcept override;
 
-	string_view getCssClass() const noexcept override { return "DirectoryBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_DIRECTORY_BOX_BUTTON; }
 	string_view getXmlTag()   const noexcept override { return ""; }
 
 	CollectionHandler* getCollectionHandler() const noexcept override {

--- a/src/Ui/Storage/Element.hpp
+++ b/src/Ui/Storage/Element.hpp
@@ -40,7 +40,7 @@ public:
 	virtual ~Element();
 
 	string_view getXmlTag()   const noexcept override { return "element"; }
-	string_view getCssClass() const noexcept override { return "ElementBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_ELEMENT_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 
 	/**

--- a/src/Ui/Storage/Group.hpp
+++ b/src/Ui/Storage/Group.hpp
@@ -39,7 +39,7 @@ public:
 	virtual ~Group() = default;
 
 	string_view getXmlTag()   const noexcept override { return "group"; }
-	string_view getCssClass() const noexcept override { return "GroupBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_GROUP_BOX_BUTTON; }
 
 	CollectionHandler* getCollectionHandler() const noexcept override {
 		return CollectionHandler::getInstance(COLLECTION_GROUPS);

--- a/src/Ui/Storage/Input.hpp
+++ b/src/Ui/Storage/Input.hpp
@@ -49,7 +49,7 @@ public:
 
 	string createUniqueId()   const noexcept override;
 	string_view getXmlTag()   const noexcept override { return "Input"; }
-	string_view getCssClass() const noexcept override { return "InputBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_INPUT_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 	string createTooltip()    const noexcept override;
 	string toXML()            const noexcept override;

--- a/src/Ui/Storage/InputMap.hpp
+++ b/src/Ui/Storage/InputMap.hpp
@@ -44,7 +44,7 @@ public:
 
 	virtual ~InputMap() = default;
 
-	string_view getCssClass() const noexcept override { return "InputMapBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_INPUT_MAP_BOX_BUTTON; }
 	string createUniqueId()   const noexcept override;
 	string createPrettyName() const noexcept override;
 	string createTooltip()    const noexcept override;

--- a/src/Ui/Storage/InputMapLink.hpp
+++ b/src/Ui/Storage/InputMapLink.hpp
@@ -41,7 +41,7 @@ public:
 	virtual ~InputMapLink() = default;
 
 	string_view getXmlTag()   const noexcept override { return emptyString; }
-	string_view getCssClass() const noexcept override { return "LinkBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_LINK_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 	string createTooltip()    const noexcept override;
 	string createUniqueId()   const noexcept override { return emptyString; }

--- a/src/Ui/Storage/InputSource.hpp
+++ b/src/Ui/Storage/InputSource.hpp
@@ -43,7 +43,7 @@ public:
 	string createUniqueId()   const noexcept override;
 	string createPrettyName() const noexcept override;
 	string createTooltip()    const noexcept override;
-	string_view getCssClass() const noexcept override { return "InputSourceBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_INPUT_SOURCE_BOX_BUTTON; }
 	string_view getXmlTag()   const noexcept override { return "maps"; }
 
 	CollectionHandler* getCollectionHandler() const noexcept override;

--- a/src/Ui/Storage/Process.hpp
+++ b/src/Ui/Storage/Process.hpp
@@ -38,7 +38,7 @@ public:
 	virtual ~Process() = default;
 
 	string_view getXmlTag()   const noexcept override { return "map"; }
-	string_view getCssClass() const noexcept override { return "ProcessBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_PROCESS_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 
 	CollectionHandler* getCollectionHandler() const noexcept override;

--- a/src/Ui/Storage/Profile.hpp
+++ b/src/Ui/Storage/Profile.hpp
@@ -42,7 +42,7 @@ public:
 	virtual ~Profile() = default;
 
 	string createUniqueId()   const noexcept override;
-	string_view getCssClass() const noexcept override { return "ProfileBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_PROFILE_BOX_BUTTON; }
 	string_view getXmlTag()   const noexcept override { return "Profile"; }
 
 	CollectionHandler* getCollectionHandler() const noexcept override {

--- a/src/Ui/Storage/Restrictor.hpp
+++ b/src/Ui/Storage/Restrictor.hpp
@@ -42,7 +42,7 @@ public:
 
 	string createPrettyName() const noexcept override;
 	string createUniqueId()   const noexcept override;
-	string_view getCssClass() const noexcept override { return "RestrictorBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_RESTRICTOR_BOX_BUTTON; }
 	string_view getXmlTag()   const noexcept override { return "restrictor"; }
 
 	CollectionHandler* getCollectionHandler() const noexcept override {

--- a/src/Ui/Storage/RestrictorMap.hpp
+++ b/src/Ui/Storage/RestrictorMap.hpp
@@ -38,7 +38,7 @@ public:
 	virtual ~RestrictorMap() = default;
 
 	string_view getXmlTag()   const noexcept override { return "map"; }
-	string_view getCssClass() const noexcept override { return "RestrictorMapBoxButton"; }
+	string_view getCssClass() const noexcept override { return CSS_RESTRICTOR_MAP_BOX_BUTTON; }
 	string createPrettyName() const noexcept override;
 	string createUniqueId()   const noexcept override;
 


### PR DESCRIPTION
- Replace Constants struct CSS members with #defines
- Rename all CSS defines to CSS_SUBJECT_INTENTION pattern
- Rename CONNECTOR_BOX → CSS_BOX_CONNECTOR
- Add missing CSS defines for all raw string literals
- Add CSS defines for all Storage::Data getCssClass() returns
- Add ICON_DELETE for edit-delete-symbolic
- Fix edit-delete → edit-delete-symbolic to match app -symbolic standard
- Replace all raw string literals and old macro names with new defines