### PR TITLE
Refactor input loading

### DIFF
--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -184,8 +184,8 @@ const string
 
 /// UI-related constants.
 	DEFAULT_ELEMENT_TYPE {"9"},
-	PLAYER   {"player"},
-	JOYSTICK {"joystick"},
+	PLAYER               {"player"},
+	JOYSTICK             {"joystick"},
 
 /// Types
 	TYPE_MAP             {"map"},
@@ -225,9 +225,14 @@ const string
 	COLLECTION_PROFILE_INPUTS     {"pr.i"},
 	COLLECTION_PROFILE_ANIMATIONS {"pr.a"},
 	COLLECTION_INPUT_MAP_LINKS    {"i.m.l"},
+
 /// Directories
 	COLLECTION_DIRECTORIES       {"ds"},
-	COLLECTION_INPUT_DIRECTORIES {"ids"};
+	COLLECTION_INPUT_DIRECTORIES {"ids"},
+
+/// Path related.
+	PATH_PARENT {"pp"},
+	PATH_BASE   {"pb"};
 
 } // namespace
 

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -180,7 +180,7 @@ const string
 	SPEED        {"speed"},      /// Input playback speed setting.
 	BLINK        {"blink"},      /// Input blink switch.
 	TIMES        {"times"},      /// Input repeat count.
-	SOURCELESS   {"sourceless"},
+	SOURCELESS   {"sl"},
 
 /// UI-related constants.
 	DEFAULT_ELEMENT_TYPE {"9"},

--- a/src/Ui/DataDialogs/DialogDirectory.cpp
+++ b/src/Ui/DataDialogs/DialogDirectory.cpp
@@ -80,11 +80,47 @@ const string& DialogDirectory::getType() const noexcept {
 	return setting->typeLabel;
 }
 
+void DialogDirectory::load(DataMap& values) noexcept {
+
+	// Clean up any cache
+	dirByPath.clear();
+
+	// Set Root
+	auto root{static_cast<Storage::DirectoryEntry*>(ownerData)};
+	dirByPath[""] = root;
+
+	// Point to store in root.
+	setting->fileDialog->setOwner(root->getPrimaryChild(), ownerData);
+	dynamic_cast<DirectoryAware*>(setting->fileDialog)->setCurrentDirectory(root);
+
+	// load root items
+	setting->fileDialog->load(values);
+
+	// load other directories.
+	createItems(values[COLLECTION_DIRECTORIES], values);
+}
+
 LEDSpicerUI::Ui::Storage::Data* DialogDirectory::createData(StringUMap& rawData) const noexcept {
-	return new Storage::DirectoryEntry(
-		rawData,
-		static_cast<Storage::DirectoryEntry*>(ownerData)
-	);
+	auto parent{dirByPath.at(rawData[PATH_PARENT])};
+	auto de{new Storage::DirectoryEntry(rawData, parent)};
+	dirByPath[de->getFullPath()] = de;
+	return de;
+}
+
+void DialogDirectory::wireChildrenDialogs() noexcept {
+	currentData->setUp();
+	auto de{static_cast<Storage::DirectoryEntry*>(currentData)};
+	setting->fileDialog->setOwner(de->getPrimaryChild(), currentData);
+	dynamic_cast<DirectoryAware*>(setting->fileDialog)->setCurrentDirectory(de);
+}
+
+void DialogDirectory::disconnectChildrenDialogs() noexcept {
+	setting->fileDialog->removeOwner();
+	currentData->tearDown();
+}
+
+void DialogDirectory::createSubItems(DataMap& values) noexcept {
+	setting->fileDialog->load(values);
 }
 
 void DialogDirectory::addButtons(Storage::BoxButton& bb) noexcept {
@@ -105,4 +141,3 @@ void DialogDirectory::addButtons(Storage::BoxButton& bb) noexcept {
 	// Standard edit/delete buttons.
 	DialogForm::addButtons(bb);
 }
-

--- a/src/Ui/DataDialogs/DialogDirectory.cpp
+++ b/src/Ui/DataDialogs/DialogDirectory.cpp
@@ -110,6 +110,10 @@ LEDSpicerUI::Ui::Storage::Data* DialogDirectory::createData(StringUMap& rawData)
 void DialogDirectory::wireChildrenDialogs() noexcept {
 	currentData->setUp();
 	auto de{static_cast<Storage::DirectoryEntry*>(currentData)};
+	if (action == Actions::LOAD) {
+		auto parentDE {static_cast<Storage::DirectoryEntry*>(de->getParent())};
+		items = parentDE->getPrimaryChild();
+	}
 	setting->fileDialog->setOwner(de->getPrimaryChild(), currentData);
 	dynamic_cast<DirectoryAware*>(setting->fileDialog)->setCurrentDirectory(de);
 }

--- a/src/Ui/DataDialogs/DialogDirectory.hpp
+++ b/src/Ui/DataDialogs/DialogDirectory.hpp
@@ -21,6 +21,7 @@
  */
 
 #include "DialogForm.hpp"
+#include "DirectoryAware.hpp"
 #include "Storage/DirectoryEntry.hpp"
 
 #pragma once
@@ -51,6 +52,10 @@ public:
 
 		/// Function to call to enter into a dir, used by BoxButtons
 		std::function<void(Storage::DirectoryEntry*)> enterDir;
+
+		/// File-type dialog wired to each directory's primary child on load (e.g. DialogInput).
+		/// nullptr if the navigator has no file dialog.
+		DialogForm* fileDialog = nullptr;
 	};
 
 	virtual ~DialogDirectory() = default;
@@ -62,7 +67,7 @@ public:
 	 */
 	void setSettings(const SettingRequest& req) noexcept;
 
-	void load(DataMap& values)    noexcept override {}
+	void load(DataMap& values)    noexcept override;
 	void clearForm()              noexcept override;
 	void storeData()              noexcept override;
 	void retrieveData()           noexcept override;
@@ -84,6 +89,14 @@ protected:
 	const string& getType() const noexcept override;
 
 	void addButtons(Storage::BoxButton& boxButton) noexcept override;
+
+	void wireChildrenDialogs()    noexcept override;
+	void disconnectChildrenDialogs() noexcept override;
+	void createSubItems(DataMap& values) noexcept override;
+
+private:
+
+	mutable std::unordered_map<string, Storage::DirectoryEntry*> dirByPath;
 
 };
 

--- a/src/Ui/DataDialogs/DialogForm.cpp
+++ b/src/Ui/DataDialogs/DialogForm.cpp
@@ -64,9 +64,11 @@ void DialogForm::createItems(StringUMapVector& rawCollection, DataMap& values) n
 		currentData->wipe();
 		storeData();
 		// BoxButton will take care for data.
-		Storage::BoxButton& b{items->create(currentData)};
-		addButtons(b);
+		Storage::BoxButton& boxButton{items->create(currentData)};
+		addButtons(boxButton);
 		createSubItems(values);
+		// updates labels and tooltips after children.
+		boxButton.sync();
 		disconnectChildrenDialogs();
 	}
 	currentData = nullptr;

--- a/src/Ui/DataDialogs/DialogInput.cpp
+++ b/src/Ui/DataDialogs/DialogInput.cpp
@@ -71,7 +71,10 @@ DialogInput::DialogInput(
 }
 
 void DialogInput::load(DataMap& values) noexcept {
-	createItems(values[COLLECTION_INPUTS], values);
+	createItems(
+		values[Defaults::createCommonUniqueId({currentDirectory->getFullPath(), COLLECTION_INPUTS})],
+		values
+	);
 }
 
 void DialogInput::createSubItems(DataMap& values) noexcept {
@@ -161,6 +164,8 @@ void DialogInput::storeData() noexcept {
 }
 
 void DialogInput::retrieveData() noexcept {
+
+	currentData->getProperties().setValue(PATH_BASE, currentData->getValue(PATH_BASE));
 
 	string name(currentData->getValue(NAME));
 

--- a/src/Ui/DataDialogs/DialogInput.cpp
+++ b/src/Ui/DataDialogs/DialogInput.cpp
@@ -84,13 +84,13 @@ void DialogInput::createSubItems(DataMap& values) noexcept {
 
 void DialogInput::resetForm() noexcept {
 	string name(selectorCombo->get_active_id());
-	bool needSources {Defaults::inputHasFlag(name, Defaults::INPUT_NEEDS_SOURCE)};
+	bool needSources {Defaults::needSource(name)};
 
 	btnAddInputSource->set_sensitive(true);
 	boxInputSourcesBox->set_visible(needSources);
 	boxInputMapsBox->set_visible(not needSources);
 
-	boxLinkedElementsAndGroups->set_visible(Defaults::inputHasFlag(name, Defaults::INPUT_LINKED_MAPS));
+	boxLinkedElementsAndGroups->set_visible(Defaults::hasLinkedMaps(name));
 
 	btnAddInputMap->set_visible(not needSources);
 	btnAddInputMap->set_sensitive(true);
@@ -135,7 +135,7 @@ void DialogInput::isValid() const {
 	}
 
 	if (action != Actions::LOAD) {
-		if (Defaults::inputHasFlag(id, Defaults::INPUT_NEEDS_SOURCE)) {
+		if (Defaults::needSource(id)) {
 			if (not DialogInputSource::getInstance()->getBox()->getSize())
 				throw Message("Add at least one source.");
 		}
@@ -210,10 +210,10 @@ void DialogInput::onEmpty() noexcept {
 }
 
 void DialogInput::onSelected() noexcept {
-	auto name{selectorCombo->get_active_id()};
+	const auto name{selectorCombo->get_active_id()};
 	const bool
-//		oldSourced {Defaults::inputHasFlag(previousName, Defaults::INPUT_NEEDS_SOURCE)},
-		newSourced {Defaults::inputHasFlag(name, Defaults::INPUT_NEEDS_SOURCE)};
+//		oldSourced {Defaults::needSource(previousName)},
+		newSourced {Defaults::needSource(name)};
 
 //	if (oldSourced and not newSourced)
 	if (newSourced)
@@ -228,6 +228,6 @@ void DialogInput::onSelected() noexcept {
 		currentData->unSet(TIMES);
 	if (not Defaults::inputHasFlag(name, Defaults::INPUT_HAS_SPEED))
 		currentData->unSet(SPEED);
-	if (not Defaults::inputHasFlag(name, Defaults::INPUT_LINKED_MAPS))
+	if (not Defaults::hasLinkedMaps(name))
 		DialogInputLinkMaps::getInstance()->clearForm();
 }

--- a/src/Ui/DataDialogs/DialogInput.cpp
+++ b/src/Ui/DataDialogs/DialogInput.cpp
@@ -219,7 +219,7 @@ void DialogInput::onSelected() noexcept {
 	if (newSourced)
 		DialogInputSource::getInstance()->populateSources(name);
 	else
-		DialogInputSource::getInstance()->createPhantomSource();
+		DialogInputSource::getInstance()->resolveSourcelessStorage();
 
 	// Drop fields the new type doesn't support.
 	if (not Defaults::inputHasFlag(name, Defaults::INPUT_HAS_BLINK))

--- a/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
+++ b/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
@@ -85,7 +85,7 @@ void DialogInputLinkMaps::load(DataMap& values) noexcept {
 	);
 }
 
-void DialogInputLinkMaps::createSubItems(DataMap& values) noexcept {
+void DialogInputLinkMaps::createSubItems(DataMap&) noexcept {
 	const string& idxStr{currentData->getValue(LINKED_ITEMS)};
 	if (idxStr.empty()) return;
 	mapsRequest.sourceCollection = CollectionHandler::getInstance(COLLECTION_INPUT_MAPS);

--- a/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
+++ b/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
@@ -80,10 +80,7 @@ void DialogInputLinkMaps::setOwner(
 
 void DialogInputLinkMaps::load(DataMap& values) noexcept {
 	createItems(
-		values[
-			Defaults::createCommonUniqueId({ownerData->createUniqueId(),
-			COLLECTION_INPUT_LINKMAPS})
-		],
+		values[Defaults::createCommonUniqueId({ownerData->getProperties().getValue(PATH_BASE), COLLECTION_INPUT_LINKMAPS})],
 		values
 	);
 }

--- a/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
+++ b/src/Ui/DataDialogs/DialogInputLinkMaps.cpp
@@ -86,7 +86,9 @@ void DialogInputLinkMaps::load(DataMap& values) noexcept {
 }
 
 void DialogInputLinkMaps::createSubItems(DataMap&) noexcept {
-	const string& idxStr{currentData->getValue(LINKED_ITEMS)};
+	// Temporary value extraction.
+	const string idxStr{currentData->getProperties().getValue(LINKED_ITEMS)};
+	currentData->getProperties().unSet(LINKED_ITEMS);
 	if (idxStr.empty()) return;
 	mapsRequest.sourceCollection = CollectionHandler::getInstance(COLLECTION_INPUT_MAPS);
 	mapsRequest.filterValue      = ownerData->getProperties().getValue(UID);
@@ -98,7 +100,7 @@ void DialogInputLinkMaps::clearForm() noexcept {
 }
 
 void DialogInputLinkMaps::isValid() const {
-	if (getPrimaryChildCollection()->getSize() < 2)
+	if (action != Actions::LOAD and getPrimaryChildCollection()->getSize() < 2)
 		throw Message("Select at least 2 maps.");
 }
 

--- a/src/Ui/DataDialogs/DialogInputLinkMaps.hpp
+++ b/src/Ui/DataDialogs/DialogInputLinkMaps.hpp
@@ -64,9 +64,9 @@ namespace LEDSpicerUI::Ui::DataDialogs {
 
 		Storage::Data* createData(StringUMap& rawData) const noexcept override;
 
-		void createSubItems(DataMap& values) noexcept override;
-		void wireChildrenDialogs()           noexcept override;
-		void disconnectChildrenDialogs()     noexcept override;
+		void createSubItems(DataMap&)    noexcept override;
+		void wireChildrenDialogs()       noexcept override;
+		void disconnectChildrenDialogs() noexcept override;
 
 	};
 

--- a/src/Ui/DataDialogs/DialogInputMap.cpp
+++ b/src/Ui/DataDialogs/DialogInputMap.cpp
@@ -118,7 +118,7 @@ void DialogInputMap::isValid() const {
 	if (inputMapDefaultColor->get_label().empty())
 		throw Message("You need to set a color.");
 
-	string uid(createUniqueId());
+	const string uid(createUniqueId());
 	if (action != Actions::EDIT or currentData->createUniqueId() != uid) {
 		if (currentData->getCollectionHandler()->isIdSet(uid))
 			throw Message("This trigger already exists for this source.");
@@ -145,13 +145,14 @@ void DialogInputMap::storeData() noexcept {
 }
 
 void DialogInputMap::retrieveData() noexcept {
+	const auto& target {currentData->getValue(TARGET)};
 	if (currentData->getValue(TYPE) == ELEMENT) {
 		stackElementAndGroup->set_visible_child("InputTypeElement");
-		comboBoxInputMapElement->set_active_id(currentData->getValue(TARGET));
+		comboBoxInputMapElement->set_active_id(target);
 	}
 	else {
 		stackElementAndGroup->set_visible_child("InputTypeGroup");
-		comboBoxInputMapGroup->set_active_id(currentData->getValue(TARGET));
+		comboBoxInputMapGroup->set_active_id(target);
 	}
 	inputInputMapTrigger->set_text(currentData->getValue(TRIGGER));
 	DialogColors::getInstance()->colorizeButton(inputMapDefaultColor, currentData->getValue(COLOR));

--- a/src/Ui/DataDialogs/DialogInputMap.cpp
+++ b/src/Ui/DataDialogs/DialogInputMap.cpp
@@ -72,7 +72,7 @@ void DialogInputMap::setNormalBox(const bool flag) noexcept {
 
 void DialogInputMap::load(DataMap& values) noexcept {
 	createItems(
-		values[Defaults::createCommonUniqueId({ownerData->createUniqueId(), COLLECTION_INPUT_MAPS})],
+		values[Defaults::createCommonUniqueId({ownerData->getProperties().getValue(PATH_BASE), COLLECTION_INPUT_MAPS})],
 		values
 	);
 }

--- a/src/Ui/DataDialogs/DialogInputSource.cpp
+++ b/src/Ui/DataDialogs/DialogInputSource.cpp
@@ -159,10 +159,7 @@ void DialogInputSource::removeOwner() noexcept {
 	DialogFormHost::removeOwner();
 }
 
-void DialogInputSource::createPhantomSource() noexcept {
-
-	// Load will create a new source.
-	if (action == Actions::LOAD) return;
+void DialogInputSource::resolveSourcelessStorage() noexcept {
 
 	// Activate the phantom immediately so the box gets populated.
 	if (items->getSize()) {
@@ -170,6 +167,10 @@ void DialogInputSource::createPhantomSource() noexcept {
 		wireChildrenDialogs();
 		return;
 	}
+
+	// Load will create a new source, stop here.
+	if (action == Actions::LOAD) return;
+
 	// Otherwise create the phantom source
 	StringUMap rawData;
 	currentData = createData(rawData);

--- a/src/Ui/DataDialogs/DialogInputSource.cpp
+++ b/src/Ui/DataDialogs/DialogInputSource.cpp
@@ -77,7 +77,7 @@ DialogInputSource::DialogInputSource(
 
 void DialogInputSource::load(DataMap& values) noexcept {
 	createItems(
-		values[Defaults::createCommonUniqueId({ownerData->createUniqueId(), COLLECTION_INPUT_SOURCES})],
+		values[Defaults::createCommonUniqueId({ownerData->getProperties().getValue(PATH_BASE), COLLECTION_INPUT_SOURCES})],
 		values
 	);
 }
@@ -93,7 +93,7 @@ void DialogInputSource::isValid() const {
 	if (currentData->getProperties().getValue(SOURCELESS).empty()) {
 		if (resolvedSource().empty()) throw Message("Enter a valid source name.");
 	}
-	if (not DialogInputMap::getInstance()->getBox()->getSize()) throw Message("Add at least one map.");
+	if (action != Actions::LOAD and not DialogInputMap::getInstance()->getBox()->getSize()) throw Message("Add at least one map.");
 }
 
 void DialogInputSource::storeData() noexcept {
@@ -116,6 +116,9 @@ void DialogInputSource::storeData() noexcept {
 }
 
 void DialogInputSource::retrieveData() noexcept {
+
+	currentData->getProperties().setValue(PATH_BASE, currentData->getValue(PATH_BASE));
+
 	// sourceless will be handled at activation.
 	if (not Defaults::needSource(comboBoxInputSelectInput->get_active_id())) return;
 

--- a/src/Ui/DataDialogs/DialogInputSource.cpp
+++ b/src/Ui/DataDialogs/DialogInputSource.cpp
@@ -47,22 +47,25 @@ DialogInputSource::DialogInputSource(
 	setSignalApply();
 
 	selectorCombo->signal_changed().connect([this]() {
-		string newName{selectorCombo->get_active_id()};
+		const string newName{selectorCombo->get_active_id()};
 		string msg;
 		if (not newName.empty() and not previousName.empty()) {
-			const auto& newInfo = Defaults::inputInfo.at(newName);
-			const auto& oldInfo = Defaults::inputInfo.at(previousName);
+			const auto
+				& newInfo = Defaults::inputInfo.at(newName),
+				& oldInfo = Defaults::inputInfo.at(previousName);
+
 			msg = "Are you sure you want to convert \"" + oldInfo.name + "\" into \"" + newInfo.name + "\"?";
-			bool oldSourced = Defaults::inputHasFlag(previousName, Defaults::INPUT_NEEDS_SOURCE);
-			bool newSourced = Defaults::inputHasFlag(newName,      Defaults::INPUT_NEEDS_SOURCE);
+			bool
+				oldSourced {Defaults::needSource(previousName)},
+				newSourced {Defaults::needSource(newName)};
+
 			if (oldSourced and not newSourced)
 				msg += "\nExtra sources will be removed. Compatible maps will be moved to the single implicit source.";
 			else if (not oldSourced and newSourced)
 				msg += "\nExisting maps will be attached to a new default source entry.";
 			else if (oldSourced and newSourced)
 				msg += "\nAll sources will be lost.";
-			if (Defaults::inputHasFlag(previousName, Defaults::INPUT_LINKED_MAPS) and
-			    not Defaults::inputHasFlag(newName,   Defaults::INPUT_LINKED_MAPS))
+			if (Defaults::hasLinkedMaps(previousName) and not Defaults::hasLinkedMaps(newName))
 				msg += "\nLinked maps are not supported and will be removed.";
 		}
 		if (handleTypeSwitch(DialogInputSource::getInstance()->getBox(), msg)) {
@@ -89,26 +92,29 @@ void DialogInputSource::resetForm() noexcept {
 }
 
 void DialogInputSource::isValid() const {
-	// no name for sourceless only.
+
+	// Verify the source for non sourceless.
 	if (currentData->getProperties().getValue(SOURCELESS).empty()) {
 		if (resolvedSource().empty()) throw Message("Enter a valid source name.");
 	}
-	if (action != Actions::LOAD and not DialogInputMap::getInstance()->getBox()->getSize()) throw Message("Add at least one map.");
+
+	if (action != Actions::LOAD and not DialogInputMap::getInstance()->getBox()->getSize())
+		throw Message("Add at least one map.");
 }
 
 void DialogInputSource::storeData() noexcept {
+
 	Glib::ustring
 		id{selectorCombo->get_active_id()},
 		label;
+
 	if (id.empty()) {
 		label = id = selectorCombo->get_entry()->get_text();
 	}
 	else {
-		auto iter = selectorCombo->get_active();
-		if (iter)
-			iter->get_value(1, label);
-		else
-			label = selectorCombo->get_entry()->get_text();
+		// Get nice label from combo.
+		const auto iter {selectorCombo->get_active()};
+		iter->get_value(1, label);
 	}
 	currentData->setValue(SOURCE, id);
 	// Store a human-friendly display label as a UI-only property.
@@ -120,9 +126,9 @@ void DialogInputSource::retrieveData() noexcept {
 	currentData->getProperties().setValue(PATH_BASE, currentData->getValue(PATH_BASE));
 
 	// sourceless will be handled at activation.
-	if (not Defaults::needSource(comboBoxInputSelectInput->get_active_id())) return;
+	if (action == Actions::LOAD and not currentData->getProperties().getValue(SOURCELESS).empty()) return;
 
-	string source(currentData->getValue(SOURCE));
+	const string& source(currentData->getValue(SOURCE));
 
 	// If setting the id fail because the source do not exists, set other and use entry instead.
 	if (not selectorCombo->set_active_id(source))
@@ -154,10 +160,13 @@ void DialogInputSource::removeOwner() noexcept {
 }
 
 void DialogInputSource::createPhantomSource() noexcept {
+
+	// Load will create a new source.
+	if (action == Actions::LOAD) return;
+
 	// Activate the phantom immediately so the box gets populated.
 	if (items->getSize()) {
-		auto& theOnlyOne = *items->begin();
-		currentData = theOnlyOne->getData();
+		currentData = (*items->begin())->getData();
 		wireChildrenDialogs();
 		return;
 	}
@@ -206,7 +215,11 @@ void DialogInputSource::createSubItems(DataMap& values) noexcept {
 }
 
 LEDSpicerUI::Ui::Storage::Data* DialogInputSource::createData(StringUMap& rawData) const noexcept {
-	return new Storage::InputSource(rawData, ownerData->getProperties().getValue(UID));
+	auto is {new Storage::InputSource(rawData, ownerData->getProperties().getValue(UID))};
+	// At load owner is realized and valid (not stale) check if is a sourceless
+	if (action == Actions::LOAD and not Defaults::needSource(ownerData->getValue(NAME)))
+		is->getProperties().setValue(SOURCELESS, "1");
+	return is;
 }
 
 StringMap DialogInputSource::scanEventDevices() noexcept{
@@ -277,10 +290,10 @@ string DialogInputSource::readDeviceName(const string& byIdName) noexcept {
 		return byIdName;
 
 	std::error_code ec;
-	auto target = std::filesystem::read_symlink(linkPath, ec);
+	const auto target {std::filesystem::read_symlink(linkPath, ec)};
 	if (ec) return byIdName;
 
-	std::filesystem::path sysPath{SYS_CLASS_INPUT + target.filename().string() + "/device/name"};
+	const std::filesystem::path sysPath {SYS_CLASS_INPUT + target.filename().string() + "/device/name"};
 	std::ifstream file(sysPath);
 	if (not file) return byIdName;
 

--- a/src/Ui/DataDialogs/DialogInputSource.hpp
+++ b/src/Ui/DataDialogs/DialogInputSource.hpp
@@ -68,7 +68,7 @@ public:
 	 * Called from Input when working with sourceless inputs.
 	 * Safe to call repeatedly, idempotent if sourceless source already exists.
 	 */
-	void createPhantomSource() noexcept;
+	void resolveSourcelessStorage() noexcept;
 
 	/**
 	 * Sourced → sourceless: collapses all sources into one phantom, discards extras.

--- a/src/Ui/DataDialogs/DialogInputSource.hpp
+++ b/src/Ui/DataDialogs/DialogInputSource.hpp
@@ -65,6 +65,7 @@ public:
 	/**
 	 * Ensures a sourceless InputSource exists for single-source inputs.
 	 * Creates one silently if absent, then wires DialogInputMap to it.
+	 * Called from Input when working with sourceless inputs.
 	 * Safe to call repeatedly, idempotent if sourceless source already exists.
 	 */
 	void createPhantomSource() noexcept;

--- a/src/Ui/DirectoryNavigator.cpp
+++ b/src/Ui/DirectoryNavigator.cpp
@@ -59,33 +59,26 @@ DirectoryNavigator::DirectoryNavigator(const Glib::RefPtr<Gtk::Builder>& builder
 	DataDialogs::DialogDirectory::buildInstance(builder, "DialogDirectory");
 }
 
-void DirectoryNavigator::loadFromDisk(const string& dir) noexcept {
+void DirectoryNavigator::process(const string& absPath, const string& relPath) noexcept {
 	namespace fs = std::filesystem;
 	std::error_code ec;
-	fs::path root(dir);
-	if (not fs::is_directory(root, ec)) return;
 
-	std::function<void(const fs::path&, Storage::DirectoryEntry*)> walk {
+	vector<fs::directory_entry> entries;
+	for (auto& e : fs::directory_iterator(absPath, ec)) entries.push_back(e);
+	std::sort(entries.begin(), entries.end());
 
-	[&](const fs::path& path, Storage::DirectoryEntry* node) {
-
-		vector<fs::directory_entry> entries;
-
-		for (auto& e : fs::directory_iterator(path, ec)) entries.push_back(e);
-		std::sort(entries.begin(), entries.end());
-
-		for (auto& entry : entries) {
-
-			if (entry.is_directory(ec)) {
-				StringUMap data{{NAME, entry.path().filename().string()}};
-				auto child {new Storage::DirectoryEntry(data, node)};
-				node->getContents().create(child);
-				walk(entry.path(), child);
-			}
-			else if (entry.is_regular_file(ec) and entry.path().extension() == ".xml") {
-				loadFile(entry.path().string(), node);
-			}
+	for (auto& entry : entries) {
+		if (entry.is_directory(ec)) {
+			string name(entry.path().filename().string());
+			string childRel(relPath.empty() ? name : relPath + "/" + name);
+			scanData[COLLECTION_DIRECTORIES].push_back({{FILENAME, name}, {PATH_PARENT, relPath}});
+			process(entry.path().string(), childRel);
 		}
-	}};
-	walk(root, &rootDir);
+		else if (entry.is_regular_file(ec) and entry.path().extension() == ".xml") {
+			DataMap fileData(extractData(entry.path().string(), relPath));
+			for (auto& [key, vec] : fileData)
+				for (auto& item : vec)
+					scanData[key].push_back(std::move(item));
+		}
+	}
 }

--- a/src/Ui/DirectoryNavigator.hpp
+++ b/src/Ui/DirectoryNavigator.hpp
@@ -86,19 +86,24 @@ protected:
 	 */
 	virtual void wireDialogs(Storage::DirectoryEntry* dir) noexcept abstract;
 
-	/**
-	 * Walks dir recursively, builds a DirectoryEntry tree, and calls loadFile() for each .xml.
-	 * Non-.xml files are silently ignored. A missing or non-directory path is a no-op.
-	 * @param dir Filesystem path to scan.
-	 */
-	void loadFromDisk(const string& dir) noexcept;
+	/// Flat scan accumulator — populated by process(), consumed by DDir::load().
+	DataMap scanData;
 
 	/**
-	 * Loads one file into the given directory node.
-	 * @param filePath Absolute path to the .xml file.
-	 * @param node Directory node that owns the file.
+	 * Recursively walks absPath, populating scanData with directory entries and
+	 * file data. Directories before files within each level (sorted order).
+	 * @param absPath Absolute filesystem path to scan.
+	 * @param relPath Navigator-relative path prefix for this level (empty = root).
 	 */
-	virtual void loadFile(const string& filePath, Storage::DirectoryEntry* node) noexcept abstract;
+	void process(const string& absPath, const string& relPath) noexcept;
+
+	/**
+	 * Parses one .xml file and returns its extracted DataMap.
+	 * @param filePath Absolute path to the .xml file.
+	 * @param relPath  Navigator-relative directory path containing the file.
+	 * @return DataMap with all data extracted from the file.
+	 */
+	virtual DataMap extractData(const string& filePath, const string& relPath) noexcept abstract;
 
 };
 

--- a/src/Ui/InputDirectoryNavigator.cpp
+++ b/src/Ui/InputDirectoryNavigator.cpp
@@ -53,6 +53,19 @@ InputDirectoryNavigator::InputDirectoryNavigator(
 	builder->get_widget("BtnAddInput",        btnAddInput);
 	builder->get_widget("BtnImportInput",     btnImportInput);
 
+	// Sort directories first, then files.
+	boxInputs->set_sort_func([](Gtk::FlowBoxChild* a, Gtk::FlowBoxChild* b) -> int {
+		auto
+			dA {static_cast<Storage::BoxButton*>(a->get_child())->getData()},
+			dB {static_cast<Storage::BoxButton*>(b->get_child())->getData()};
+		const bool
+			aIsDir {dynamic_cast<Storage::DirectoryEntry*>(dA) != nullptr},
+			bIsDir {dynamic_cast<Storage::DirectoryEntry*>(dB) != nullptr};
+		if (aIsDir != bIsDir)
+			return aIsDir ? -1 : 1;
+		return dynamic_cast<Storage::DirNode*>(dA)->getName().compare(dynamic_cast<Storage::DirNode*>(dB)->getName());
+	});
+
 	// Register automatic buttons.
 	auto chEl {Storage::CollectionHandler::getInstance(COLLECTION_ELEMENTS)};
 	chEl->registerSensitivity(btnAddInput);

--- a/src/Ui/InputDirectoryNavigator.cpp
+++ b/src/Ui/InputDirectoryNavigator.cpp
@@ -39,6 +39,7 @@ InputDirectoryNavigator::InputDirectoryNavigator(
 {
 
 	DataDialogs::DialogInput::buildInstance(builder, "DialogInput");
+	dirSetting.fileDialog = DataDialogs::DialogInput::getInstance();
 
 	Gtk::Button
 		* btnNewInputFolder = nullptr,
@@ -66,7 +67,7 @@ InputDirectoryNavigator::InputDirectoryNavigator(
 			StringVector selectedFiles(dialogImportInput.get_filenames());
 			for (const auto& selectedFile : selectedFiles) {
 				try {
-					InputFile datafile(selectedFile, currentDir);
+					InputFile datafile(selectedFile, currentDir->getFullPath());
 					DataDialogs::DialogInput::getInstance()->load(datafile.getDataMap());
 				}
 				catch (Message& e) {
@@ -93,18 +94,25 @@ void InputDirectoryNavigator::clear() noexcept {
 }
 
 void InputDirectoryNavigator::load(const string& inputsDir) noexcept {
-	loadFromDisk(inputsDir);
+	scanData.clear();
+	process(inputsDir, "");
+	auto DDir {DataDialogs::DialogDirectory::getInstance()};
+	// Set Input Dialog as secondary.
+	DDir->setSettings(dirSetting);
+	// Set Storage into root
+	DDir->setOwner(rootDir.getPrimaryChild(), &rootDir);
+	DDir->load(scanData);
 }
 
 void InputDirectoryNavigator::wireDialogs(Storage::DirectoryEntry* dir) noexcept {
 
-	Storage::BoxButtonCollection& contents{dir->getContents()};
-
-	// Always configure the section before wiring — fires before any button can be pressed.
 	DataDialogs::DialogDirectory::getInstance()->setSettings(dirSetting);
-	DataDialogs::DialogDirectory::getInstance()->setOwner(&contents, dir);
+	DataDialogs::DialogDirectory::getInstance()->setOwner(dir->getPrimaryChild(), dir);
 
-	DataDialogs::DialogInput::getInstance()->setOwner(&contents, dir);
+	DataDialogs::DialogInput::getInstance()->setOwner(dir->getPrimaryChild(), dir);
+	DataDialogs::DialogInput::getInstance()->setCurrentDirectory(dir);
+
+	DataDialogs::DialogDirectory::getInstance()->refreshItems();
 
 	// Update navigation buttons.
 	btnHome->set_sensitive(not isAtRoot());
@@ -148,15 +156,15 @@ void InputDirectoryNavigator::wireDialogs(Storage::DirectoryEntry* dir) noexcept
 }
 
 
-void InputDirectoryNavigator::loadFile(const string& filePath, Storage::DirectoryEntry* node) noexcept {
+DataMap InputDirectoryNavigator::extractData(const string& filePath, const string& relPath) noexcept {
 	try {
-		InputFile datafile(filePath, node);
-		DataDialogs::DialogInput::getInstance()->setOwner(&node->getContents(), node);
-		DataDialogs::DialogInput::getInstance()->load(datafile.getDataMap());
+		InputFile datafile(filePath, relPath);
+		return datafile.getDataMap();
 	}
 	catch (Message& e) {
 		Message::displayError(
 			"Skipping " + Glib::path_get_basename(filePath) +
 			":\n" + XMLHelper::cleanError(e.getMessage()));
+		return {};
 	}
 }

--- a/src/Ui/InputDirectoryNavigator.hpp
+++ b/src/Ui/InputDirectoryNavigator.hpp
@@ -57,7 +57,7 @@ protected:
 	/// Import input dialog.
 	DialogImport dialogImportInput;
 
-	Gtk::Box* boxBreadcrumb  = nullptr;
+	Gtk::Box* boxBreadcrumb = nullptr;
 
 	Gtk::Button * btnHome = nullptr;
 

--- a/src/Ui/InputDirectoryNavigator.hpp
+++ b/src/Ui/InputDirectoryNavigator.hpp
@@ -65,11 +65,11 @@ protected:
 	OrdenableFlowBox* boxInputs = nullptr;
 
 	/// Section settings for DialogDirectory. References boxInputs — declared after it.
-	const DataDialogs::DialogDirectory::SettingRequest dirSetting;
+	DataDialogs::DialogDirectory::SettingRequest dirSetting;
 
 	void wireDialogs(Storage::DirectoryEntry* dir) noexcept override;
 
-	void loadFile(const string& filePath, Storage::DirectoryEntry* node) noexcept override;
+	DataMap extractData(const string& filePath, const string& relPath) noexcept override;
 };
 
 } // namespace

--- a/src/Ui/Storage/DirectoryEntry.cpp
+++ b/src/Ui/Storage/DirectoryEntry.cpp
@@ -28,7 +28,7 @@ DirectoryEntry::DirectoryEntry(
 	StringUMap&     data,
 	DirectoryEntry* parent
 ) noexcept :
-	Data(data),
+	Parent(data, {COLLECTION_DIRECTORIES}),
 	DirNode(getProperties(), parent, getValue(FILENAME))
 {}
 
@@ -47,6 +47,3 @@ string DirectoryEntry::createTooltip() const noexcept {
 	return getFullPath();
 }
 
-bool DirectoryEntry::isEmpty() const noexcept {
-	return not contents.getSize();
-}

--- a/src/Ui/Storage/DirectoryEntry.hpp
+++ b/src/Ui/Storage/DirectoryEntry.hpp
@@ -20,7 +20,7 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "CollectionHandler.hpp"
+#include "Parent.hpp"
 #include "DirNode.hpp"
 
 #pragma once
@@ -31,11 +31,11 @@ namespace LEDSpicerUI::Ui::Storage {
  * LEDSpicerUI::Ui::Storage::DirectoryEntry
  * Represents a single directory node in the navigator tree.
  * Never serialized — exists only at runtime for navigation.
- * Inherits Data for BoxButton compatibility.
+ * Inherits Parent for child item storage (dirs + inputs share COLLECTION_DIRECTORIES).
  * Inherits DirNode for node identity and path resolution.
  * TODO: add move support — requires reseating parent pointer on move.
  */
-class DirectoryEntry : public Data, public DirNode {
+class DirectoryEntry : public Parent, public DirNode {
 
 public:
 
@@ -56,16 +56,6 @@ public:
 	CollectionHandler* getCollectionHandler() const noexcept override {
 		return CollectionHandler::getInstance(COLLECTION_DIRECTORIES);
 	}
-
-	bool isEmpty() const noexcept;
-
-	BoxButtonCollection& getContents() noexcept { return contents; }
-	const BoxButtonCollection& getContents() const noexcept { return contents; }
-
-protected:
-
-	/// Items owned by this directory.
-	BoxButtonCollection contents;
 
 };
 

--- a/src/Ui/Storage/DirectoryEntry.hpp
+++ b/src/Ui/Storage/DirectoryEntry.hpp
@@ -31,7 +31,7 @@ namespace LEDSpicerUI::Ui::Storage {
  * LEDSpicerUI::Ui::Storage::DirectoryEntry
  * Represents a single directory node in the navigator tree.
  * Never serialized — exists only at runtime for navigation.
- * Inherits Parent for child item storage (dirs + inputs share COLLECTION_DIRECTORIES).
+ * Inherits Parent for child item storage.
  * Inherits DirNode for node identity and path resolution.
  * TODO: add move support — requires reseating parent pointer on move.
  */

--- a/src/Ui/Storage/Input.cpp
+++ b/src/Ui/Storage/Input.cpp
@@ -32,7 +32,7 @@ string Input::createUniqueId() const noexcept {
 }
 
 string Input::createPrettyName() const noexcept {
-	return getFullPath() + " [" + getValue(NAME) + "]";
+	return getName() + " [" + getValue(NAME) + "]";
 }
 
 string Input::createTooltip() const noexcept {

--- a/src/Ui/Storage/InputMapLink.cpp
+++ b/src/Ui/Storage/InputMapLink.cpp
@@ -32,10 +32,9 @@ InputMapLink::InputMapLink(StringUMap& data, const string& inputPid) noexcept :
 }
 
 string InputMapLink::createPrettyName() const noexcept {
-	StringVector names;
-	for (auto btn : *primaryChild)
-		names.push_back(btn->getData()->createPrettyName());
-	return names.empty() ? "Empty" : Defaults::implode(names, " ➡️ ") + " 🔙";
+	const auto size {primaryChild->getSize()};
+	if (not size) return "Empty";
+	return "Linked " + std::to_string(size) + " Maps";
 }
 
 string InputMapLink::createTooltip() const noexcept {

--- a/src/Ui/Storage/InputMapLink.cpp
+++ b/src/Ui/Storage/InputMapLink.cpp
@@ -29,6 +29,8 @@ InputMapLink::InputMapLink(StringUMap& data, const string& inputPid) noexcept :
 {
 	getProperties().setValue(PID, inputPid);
 	registerDependency(COLLECTION_INPUT_MAPS, COLLECTION_INPUT_MAP_LINKS);
+	// Load data only.
+	getProperties().setValue(LINKED_ITEMS, getValue(LINKED_ITEMS));
 }
 
 string InputMapLink::createPrettyName() const noexcept {
@@ -53,7 +55,7 @@ string InputMapLink::toXML() const noexcept {
 	StringVector indexes;
 	size_t idx{0};
 	for (const auto& [id, data] : *CollectionHandler::getInstance(COLLECTION_INPUT_MAPS)) {
-		if (data->getProperties().getValue(PID) == pid) {
+		if (data->getProperties().getValue(IID) == pid) {
 			if (primaryChild->isSet(data))
 				indexes.push_back(std::to_string(idx));
 			++idx;

--- a/src/Ui/Storage/Link.cpp
+++ b/src/Ui/Storage/Link.cpp
@@ -49,8 +49,10 @@ string_view Link::getXmlTag() const noexcept {
 }
 
 const string& Link::getValue(const string& key) const noexcept {
-	if (key == linkKey)
-		return link->getPrimaryValue();
+	if (key == linkKey) {
+		return link ? link->getPrimaryValue() : emptyString;
+	}
+
 	return Data::getValue(key);
 }
 

--- a/src/config/InputFile.cpp
+++ b/src/config/InputFile.cpp
@@ -24,20 +24,16 @@
 
 using namespace LEDSpicerUI::Config;
 
-using LEDSpicerUI::Ui::Storage::DirectoryEntry;
-
-InputFile::InputFile(const string& filePath, DirectoryEntry* parent) :
-	ProjectFile(filePath, "Input", parent)
+InputFile::InputFile(const string& filePath, const string& relPath) :
+	ProjectFile(filePath, "Input", nullptr)
 {
 	string errors;
 
-	string baseId(Defaults::createCommonUniqueId({
-		parent ? parent->getFsId() : "",
-		filename
-	}));
+	string baseId(Defaults::createCommonUniqueId({relPath, filename}));
 
 	StringUMap input(rootInfo.attributes);
-	input[FILENAME] = filename;
+	input[FILENAME]  = filename;
+	input[PATH_BASE] = baseId;
 
 	tinyxml2::XMLElement* mapsNode = getRoot()->FirstChildElement("maps");
 	if (not mapsNode) {
@@ -47,10 +43,13 @@ InputFile::InputFile(const string& filePath, DirectoryEntry* parent) :
 		StringUMapVector mapsSources;
 
 		for (size_t idx = 0; mapsNode; mapsNode = mapsNode->NextSiblingElement("maps"), ++idx) {
-			mapsSources.push_back(processNode(mapsNode));
+			StringUMap source(processNode(mapsNode));
+			string sourceBaseId(Defaults::createCommonUniqueId({baseId, std::to_string(idx)}));
+			source[PATH_BASE] = sourceBaseId;
+			mapsSources.push_back(std::move(source));
 			errors += processMaps(
 				mapsNode,
-				Defaults::createCommonUniqueId({baseId, std::to_string(idx), COLLECTION_INPUT_MAPS})
+				Defaults::createCommonUniqueId({sourceBaseId, COLLECTION_INPUT_MAPS})
 			);
 		}
 
@@ -62,7 +61,10 @@ InputFile::InputFile(const string& filePath, DirectoryEntry* parent) :
 
 	processLinkedTriggers(baseId);
 
-	extractedData.emplace(COLLECTION_INPUTS, StringUMapVector{input});
+	extractedData.emplace(
+		Defaults::createCommonUniqueId({relPath, COLLECTION_INPUTS}),
+		StringUMapVector{input}
+	);
 
 	if (not errors.empty())
 		throw Message("Errors:\n" + errors);

--- a/src/config/InputFile.hpp
+++ b/src/config/InputFile.hpp
@@ -39,10 +39,10 @@ public:
 
 	/**
 	 * @param filePath Full path to the .xml file on disk.
-	 * @param parent Owning directory node, or nullptr for root level.
+	 * @param relPath  Relative path from the navigator root (empty string for root level).
 	 * @throws Message on parse errors.
 	 */
-	InputFile(const string& filePath, DirectoryEntry* parent);
+	InputFile(const string& filePath, const string& relPath);
 
 	virtual ~InputFile() = default;
 

--- a/tests/Ui/Storage/DirectoryEntryTest.cpp
+++ b/tests/Ui/Storage/DirectoryEntryTest.cpp
@@ -104,14 +104,12 @@ TEST_F(DirectoryEntryTest, CreateTooltip) {
 	EXPECT_EQ("root/subdir", child->createTooltip());
 }
 
-// isEmpty() reflects contents.
 TEST_F(DirectoryEntryTest, IsEmptyWhenNoContents) {
-	EXPECT_TRUE(root->isEmpty());
+	EXPECT_EQ(0, root->getSize());
 }
 
-// getContents() is writable.
 TEST_F(DirectoryEntryTest, GetContentsIsWritable) {
-	EXPECT_EQ(0, root->getContents().getSize());
+	EXPECT_EQ(0, root->getChildren().size());
 }
 
 int main(int argc, char** argv) {

--- a/tests/Ui/Storage/DirectoryEntryTest.cpp
+++ b/tests/Ui/Storage/DirectoryEntryTest.cpp
@@ -108,10 +108,6 @@ TEST_F(DirectoryEntryTest, IsEmptyWhenNoContents) {
 	EXPECT_EQ(0, root->getSize());
 }
 
-TEST_F(DirectoryEntryTest, GetContentsIsWritable) {
-	EXPECT_EQ(0, root->getChildren().size());
-}
-
 int main(int argc, char** argv) {
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();

--- a/tests/Ui/Storage/InputTest.cpp
+++ b/tests/Ui/Storage/InputTest.cpp
@@ -78,13 +78,6 @@ TEST_F(InputTest, CreatePrettyNameAtRoot) {
 	EXPECT_NE(string::npos, pretty.find("Actions"));
 }
 
-TEST_F(InputTest, CreatePrettyNameNested) {
-	string pretty(nestedInput->createPrettyName());
-	EXPECT_NE(string::npos, pretty.find("stub_1"));
-	EXPECT_NE(string::npos, pretty.find("nestedinput"));
-	EXPECT_NE(string::npos, pretty.find("Mame"));
-}
-
 TEST_F(InputTest, CreateUniqueIdAtRoot) {
 	EXPECT_EQ(
 		Defaults::createCommonUniqueId({emptyString, "myinput"}),

--- a/tests/Ui/Storage/LeafDataTest.cpp
+++ b/tests/Ui/Storage/LeafDataTest.cpp
@@ -179,7 +179,7 @@ TEST_F(InputMapLinkTest, ToXMLWithSingleLink) {
 
 	StringUMap d{{NAME, "m1"}};
 	Element map(d);
-	map.getProperties().setValue(PID, "owner_1");
+	map.getProperties().setValue(IID, "owner_1");
 	CollectionHandler::getInstance(COLLECTION_INPUT_MAPS)->add(&map);
 
 	StringUMap imlData;
@@ -204,9 +204,9 @@ TEST_F(InputMapLinkTest, ToXMLSkipsUnlinkedAndFollowsCollectionOrder) {
 	tempMaps->add(&map2);
 	tempMaps->add(&map3);
 
-	map1.getProperties().setValue(PID, "owner_1");
-	map2.getProperties().setValue(PID, "owner_1");
-	map3.getProperties().setValue(PID, "owner_1");
+	map1.getProperties().setValue(IID, "owner_1");
+	map2.getProperties().setValue(IID, "owner_1");
+	map3.getProperties().setValue(IID, "owner_1");
 
 	StringUMap imlData;
 	InputMapLink iml(imlData, "owner_1");

--- a/tests/config/InputFileTest.cpp
+++ b/tests/config/InputFileTest.cpp
@@ -31,8 +31,8 @@ class InputFileTest : public ::testing::Test {
 protected:
 
 	void SetUp() override {
-		inputMulti  = std::make_unique<InputFile>(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMulti.xml",  nullptr);
-		inputSingle = std::make_unique<InputFile>(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", nullptr);
+		inputMulti  = std::make_unique<InputFile>(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMulti.xml",  "");
+		inputSingle = std::make_unique<InputFile>(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", "");
 	}
 
 	void TearDown() override {
@@ -44,16 +44,24 @@ protected:
 	std::unique_ptr<InputFile> inputSingle;
 
 	/*
-	 * Builds the base collection key for a file at root level (nullptr parent).
+	 * Builds the base collection key for a file at root level (empty relPath).
 	 * Matches InputFile::InputFile() → createCommonUniqueId({"", filename}).
 	 */
 	static string baseId(const string& filename) {
 		return Defaults::createCommonUniqueId({"", filename});
 	}
+
+	/*
+	 * Builds the inputs collection key for root-level files.
+	 * Matches InputFile::InputFile() → createCommonUniqueId({"", COLLECTION_INPUTS}).
+	 */
+	static string inputsKey() {
+		return Defaults::createCommonUniqueId({"", COLLECTION_INPUTS});
+	}
 };
 
 TEST_F(InputFileTest, MultiSourceInputIsLoaded) {
-	auto& inputData = inputMulti->getData(COLLECTION_INPUTS);
+	auto& inputData = inputMulti->getData(inputsKey());
 	ASSERT_FALSE(inputData.empty());
 	ASSERT_FALSE(inputData[0].empty());
 
@@ -114,7 +122,7 @@ TEST_F(InputFileTest, SecondSourceMapsAreProcessed) {
 }
 
 TEST_F(InputFileTest, SingleSourceInputIsLoaded) {
-	auto& inputData = inputSingle->getData(COLLECTION_INPUTS);
+	auto& inputData = inputSingle->getData(inputsKey());
 	ASSERT_FALSE(inputData.empty());
 	EXPECT_EQ("Mame", inputData[0][NAME]);
 	EXPECT_EQ("inputSingle", inputSingle->getFilename());
@@ -147,7 +155,7 @@ TEST_F(InputFileTest, SingleSourceMapsAreProcessed) {
 
 TEST_F(InputFileTest, MissingAttributesHandling) {
 	EXPECT_THROW(
-		InputFile(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMalformed.xml", nullptr),
+		InputFile(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMalformed.xml", ""),
 		Message
 	);
 }

--- a/tests/config/ProjectFileTest.cpp
+++ b/tests/config/ProjectFileTest.cpp
@@ -35,23 +35,25 @@ class ProjectFileTest : public ::testing::Test {};
 
 // Basename is extracted from the full path — no extension, no directory prefix.
 TEST_F(ProjectFileTest, FilenameExtractionSimple) {
-	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", nullptr);
+	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", "");
 	EXPECT_EQ("inputSingle", input.getFilename());
+
+
 }
 
 TEST_F(ProjectFileTest, FilenameExtractionMulti) {
-	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMulti.xml", nullptr);
+	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputMulti.xml", "");
 	EXPECT_EQ("inputMulti", input.getFilename());
 }
 
 // Extension must be stripped.
 TEST_F(ProjectFileTest, FilenameRemovesExtension) {
-	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", nullptr);
+	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", "");
 	EXPECT_EQ(string::npos, input.getFilename().find(".xml")) << "Extension should be removed";
 }
 
 // With nullptr parent the file is at root level.
 TEST_F(ProjectFileTest, NullParentReturnsNullptr) {
-	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", nullptr);
+	InputFile input(PACKAGE_SAMPLES_DIR "data/" INPUT_PATH "inputSingle.xml", "");
 	EXPECT_EQ(nullptr, input.getParent());
 }


### PR DESCRIPTION
## Refactor Input Loading

This PR refactors the input loading mechanism to decouple directory navigation from data loading and improve path tracking throughout the hierarchy.

### Key Changes

**Directory Navigation Refactoring**
- Converted recursive tree-building in `DirectoryNavigator` to a flat scan approach to simplify loading.
- Changed `loadFromDisk()` → `process()`: now accumulates flat data structures instead of building in-place
- Changed abstract `loadFile()` → `extractData()`: files now return their data rather than directly wiring dialogs
- New `DirectoryNavigator::scanData` accumulator populated during scan, consumed by `DialogDirectory::load()`

**Path Tracking**
- Introduced `PATH_BASE` and `PATH_PARENT` constants for tracking hierarchical paths
- Each data object now tracks its position in the hierarchy via path properties
- InputFile now accepts `relPath` (relative path from navigator root) instead of parent pointer

**Data Structure Updates**
- `DirectoryEntry` now inherits from `Parent` instead of `Data` for proper child storage
- Removed `getContents()`, `isEmpty()` from DirectoryEntry — now delegated to `Parent`
- Added dialog wiring methods to DirectoryEntry and Input dialogs: `wireChildrenDialogs()`, `disconnectChildrenDialogs()`, `createSubItems()`
- SettingRequest in InputDirectoryNavigator changed from const to mutable to hold fileDialog reference

**Dialog Improvements**
- `DialogDirectory` now implements full `load()` instead of no-op
- `DialogInput`, `DialogInputSource`, `DialogInputMap`, `DialogInputLinkMaps` updated to use `PATH_BASE` for correct ID lookups
- Simplified dialog switching logic and improved method signatures

**Code Quality**
- Added several `const` qualifiers to local variables
- Improved formatting and const-correctness in multiple dialog classes
- Updated test assertions to use new API
