### PR TITLE
Rewrite DirNodeTest to test only DirNode-specific behavior

### DIFF
--- a/tests/Ui/Storage/DirNodeTest.cpp
+++ b/tests/Ui/Storage/DirNodeTest.cpp
@@ -22,31 +22,30 @@
 
 #include "MockBasicData.hpp"
 #include "Storage/DirNode.hpp"
-#include "Storage/Data.hpp"
 
 using namespace LEDSpicerUI::Ui::Storage;
 using namespace LEDSpicerUI::Constants;
 using LEDSpicerUI::Test::Mocks::MockBasicData;
 
-// Minimal concrete consumer for testing DirNode in isolation.
+// Minimal concrete class for testing DirNode in isolation.
 class TestNode : public MockBasicData, public DirNode {
 
 public:
 
 	TestNode(Values& data, DirNode* parent, const string& filename) noexcept :
-		Parent(data, {}),
+		MockBasicData(data),
 		DirNode(getProperties(), parent, filename)
 	{}
 };
 
-TEST(DirectoryEntryTest, TestFunctionality) {
+TEST(DirNodeTest, TestFunctionality) {
 
 	Values data;
-	TestNode root {data, nullptr, "root"};
-	TestNode child {data, &root, "child"};
-	TestNode grand {data, &child, "deep"};
+	TestNode root  {data, nullptr, "root"};
+	TestNode child {data, &root,   "child"};
+	TestNode grand {data, &child,  "deep"};
 
-	// UID is set and is non-empty.
+	// UID written and non-empty.
 	EXPECT_FALSE(root.getProperties().getValue(UID).empty());
 
 	// PID is empty at root level.
@@ -56,33 +55,29 @@ TEST(DirectoryEntryTest, TestFunctionality) {
 	EXPECT_EQ(root.getProperties().getValue(UID),  child.getProperties().getValue(PID));
 	EXPECT_EQ(child.getProperties().getValue(UID), grand.getProperties().getValue(PID));
 
-	// getFsId() aliases dest UID.
+	// getFsId() aliases UID.
 	EXPECT_EQ(root.getProperties().getValue(UID),  root.getFsId());
 	EXPECT_EQ(child.getProperties().getValue(UID), child.getFsId());
 
-	// getName() returns the name passed at construction.
-	EXPECT_EQ("root",   root.getName());
-	EXPECT_EQ("subdir", child.getName());
-	EXPECT_EQ("deep",   grand.getName());
+	// getName() returns the filename segment.
+	EXPECT_EQ("root",  root.getName());
+	EXPECT_EQ("child", child.getName());
+	EXPECT_EQ("deep",  grand.getName());
 
-	// createUniqueId() uses PID + name.
-	EXPECT_EQ(Defaults::createCommonUniqueId({emptyString, "root"}), root.createUniqueId());
+	// getParent() and isAtRoot().
+	EXPECT_EQ(nullptr, root.getParent());
+	EXPECT_EQ(&root,   child.getParent());
+	EXPECT_TRUE(root.isAtRoot());
+	EXPECT_FALSE(child.isAtRoot());
 
-	// Create unique Id nested.
-	EXPECT_EQ(Defaults::createCommonUniqueId({root.getFsId(), "subdir"}), child.createUniqueId());
-
-	// createPrettyName() prefixes with folder emoji.
-	EXPECT_NE(string::npos, root.createPrettyName().find("root"));
-	EXPECT_NE(string::npos, root.createPrettyName().find("📁"));
-
-	// createTooltip() returns full path.
-	EXPECT_EQ("root", root.createTooltip());
-	EXPECT_EQ("root/subdir/deep", grand.createTooltip());
+	// getPath() returns the parent's full path.
+	EXPECT_EQ(emptyString,  root.getPath());
+	EXPECT_EQ("root",       child.getPath());
+	EXPECT_EQ("root/child", grand.getPath());
 
 	// getFullPath() includes own name segment.
-	EXPECT_EQ("myfile", root.getFullPath());
-	EXPECT_EQ("subdir/nestedfile", grand.getFullPath());
+	EXPECT_EQ("root",            root.getFullPath());
+	EXPECT_EQ("root/child",      child.getFullPath());
+	EXPECT_EQ("root/child/deep", grand.getFullPath());
 
 }
-
-

--- a/tests/Ui/Storage/DirectoryEntryTest.cpp
+++ b/tests/Ui/Storage/DirectoryEntryTest.cpp
@@ -30,48 +30,27 @@ using LEDSpicerUI::Values;
 
 TEST(DirectoryEntryTest, TestFunctionality) {
 
-	Values rootData {{FILENAME, "root"}};
+	Values rootData  {{FILENAME, "root"}};
 	DirectoryEntry root {rootData, nullptr};
 
-	// Check empty.
-	EXPECT_EQ(0, root.getSize());
-
-	Values childData {{FILENAME, "subdir"}};
+	Values childData {{FILENAME, "child"}};
 	DirectoryEntry child {childData, &root};
-	Values grandData {{FILENAME, "deep"}};
-	DirectoryEntry grand {grandData, &child};
 
-	// UID is set and is non-empty.
-	EXPECT_FALSE(root.getProperties().getValue(UID).empty());
-
-	// PID is empty at root level.
-	EXPECT_EQ(emptyString, root.getProperties().getValue(PID));
-
-	// PID matches parent UID.
-	EXPECT_EQ(root.getProperties().getValue(UID),  child.getProperties().getValue(PID));
-	EXPECT_EQ(child.getProperties().getValue(UID), grand.getProperties().getValue(PID));
-
-	// getFsId() aliases dest UID.
-	EXPECT_EQ(root.getProperties().getValue(UID),  root.getFsId());
-	EXPECT_EQ(child.getProperties().getValue(UID), child.getFsId());
-
-	// getName() returns the name passed at construction.
-	EXPECT_EQ("root",   root.getName());
-	EXPECT_EQ("subdir", child.getName());
-	EXPECT_EQ("deep",   grand.getName());
+	// getCssClass, getXmlTag, getCollectionHandler.
+	EXPECT_EQ(CSS_DIRECTORY_BOX_BUTTON, root.getCssClass());
+	EXPECT_EQ(emptyString,              root.getXmlTag());
+	EXPECT_NE(nullptr,                  root.getCollectionHandler());
 
 	// createUniqueId() uses PID + name.
-	EXPECT_EQ(Defaults::createCommonUniqueId({emptyString, "root"}), root.createUniqueId());
-
-	// Create unique Id nested.
-	EXPECT_EQ(Defaults::createCommonUniqueId({root.getFsId(), "subdir"}), child.createUniqueId());
+	EXPECT_EQ(Defaults::createCommonUniqueId({emptyString,    "root"}),  root.createUniqueId());
+	EXPECT_EQ(Defaults::createCommonUniqueId({root.getFsId(), "child"}), child.createUniqueId());
 
 	// createPrettyName() prefixes with folder emoji.
 	EXPECT_NE(string::npos, root.createPrettyName().find("root"));
 	EXPECT_NE(string::npos, root.createPrettyName().find("📁"));
 
 	// createTooltip() returns full path.
-	EXPECT_EQ("root", root.createTooltip());
-	EXPECT_EQ("root/subdir/deep", grand.createTooltip());
+	EXPECT_EQ("root",       root.createTooltip());
+	EXPECT_EQ("root/child", child.createTooltip());
 
 }


### PR DESCRIPTION
Fix test suite name collision with DirectoryEntryTest, correct broken TestNode constructor, remove DirectoryEntry-only method tests (createUniqueId, createPrettyName, createTooltip), and add missing DirNode tests for getParent, isAtRoot, getPath, and correct getFullPath expectations.