### PR TITLE
74: Layout: in-place element editing + snap-to-grid + UX polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(ledspicerui
 	src/Ui/Layout/StripRenderer.cpp
 	src/Ui/Layout/LayoutTester.cpp
 	src/Ui/Layout/LayoutElement.cpp
+	src/Ui/Layout/LayoutBoard.cpp
 	src/Ui/Layout/Layout.cpp
 	src/Ui/Storage/CollectionHandler.cpp
 	src/Ui/Storage/Data.cpp

--- a/data/main.glade.in
+++ b/data/main.glade.in
@@ -148,6 +148,12 @@ Author: Patricio A Rossi
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustmentLayoutGrid">
+    <property name="lower">0</property>
+    <property name="upper">100</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkApplicationWindow" id="MainWindow">
     <property name="can-focus">False</property>
     <child>
@@ -5277,6 +5283,49 @@ Autodetected if ledspicer is installed</property>
                     <property name="title" translatable="yes">General</property>
                     <property name="icon-name">preferences-system-symbolic</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="ypad">4</property>
+                        <property name="label" translatable="yes">Snap-to-grid</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScale" id="ScaleLayoutGrid">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Changes the size of the grid in the Layout, 0 to disable the grid.</property>
+                        <property name="adjustment">adjustmentLayoutGrid</property>
+                        <property name="round-digits">0</property>
+                        <property name="digits">0</property>
+                        <property name="value-pos">right</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">layout</property>
+                    <property name="title" translatable="yes">Layout</property>
+                    <property name="icon-name">view-grid-symbolic</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>

--- a/data/style-base.css
+++ b/data/style-base.css
@@ -1,4 +1,3 @@
-
 /* ============================================================
  * LEDSpicerUI — Base Structural CSS
  * Layout, sizing, spacing, and hardware-semantic colors.
@@ -225,8 +224,8 @@ combobox.noRoundRight button.combo,
 }
 
 .layout-element-active {
-	border:     1px solid #1c71d8;
-	background: rgba(28,113,216,0.12);
+	border:     1px solid #ccc;
+	background: rgba(13,13,13,0.62);
 }
 
 .layout-element-icon {
@@ -279,14 +278,15 @@ combobox.noRoundRight button.combo,
 
 /* RGB toggle row: dim outline when off, full color when checked.
  * Scoped with :not(.strip-led) so strip cells use the .strip-led
- * swatch rules above instead of the toggle variants. */
-button.led-r:not(.strip-led),
-button.led-g:not(.strip-led),
-button.led-b:not(.strip-led),
-button.led-y:not(.strip-led),
-button.led-m:not(.strip-led),
-button.led-c:not(.strip-led),
-button.led-w:not(.strip-led) {
+ * swatch rules above, and :not(.layout-element-icon) so the icon
+ * toggle uses its own .layout-element-icon-fired rules. */
+button.led-r:not(.strip-led):not(.layout-element-icon),
+button.led-g:not(.strip-led):not(.layout-element-icon),
+button.led-b:not(.strip-led):not(.layout-element-icon),
+button.led-y:not(.strip-led):not(.layout-element-icon),
+button.led-m:not(.strip-led):not(.layout-element-icon),
+button.led-c:not(.strip-led):not(.layout-element-icon),
+button.led-w:not(.strip-led):not(.layout-element-icon) {
 	background-image: none;
 	background-color: #2a2a2a;
 	border:           1px solid #555;
@@ -296,17 +296,17 @@ button.led-w:not(.strip-led) {
 	min-height:       0;
 }
 
-button.led-r:not(.strip-led)         { border-color: #e01b24; }
-button.led-g:not(.strip-led)         { border-color: #3da81b; }
-button.led-b:not(.strip-led)         { border-color: #1c71d8; }
+button.led-r:not(.strip-led):not(.layout-element-icon)         { border-color: #e01b24; }
+button.led-g:not(.strip-led):not(.layout-element-icon)         { border-color: #3da81b; }
+button.led-b:not(.strip-led):not(.layout-element-icon)         { border-color: #1c71d8; }
 
-button.led-r:not(.strip-led):hover   { background-color: rgba(224,27,36,0.30); }
-button.led-g:not(.strip-led):hover   { background-color: rgba(61,168,27,0.30); }
-button.led-b:not(.strip-led):hover   { background-color: rgba(28,113,216,0.30); }
+button.led-r:not(.strip-led):not(.layout-element-icon):hover   { background-color: rgba(224,27,36,0.30); }
+button.led-g:not(.strip-led):not(.layout-element-icon):hover   { background-color: rgba(61,168,27,0.30); }
+button.led-b:not(.strip-led):not(.layout-element-icon):hover   { background-color: rgba(28,113,216,0.30); }
 
-button.led-r:not(.strip-led):checked { background-color: #e01b24; border-color: #fff; }
-button.led-g:not(.strip-led):checked { background-color: #3da81b; border-color: #fff; }
-button.led-b:not(.strip-led):checked { background-color: #1c71d8; border-color: #fff; }
+button.led-r:not(.strip-led):not(.layout-element-icon):checked { background-color: #e01b24; border-color: #fff; }
+button.led-g:not(.strip-led):not(.layout-element-icon):checked { background-color: #3da81b; border-color: #fff; }
+button.led-b:not(.strip-led):not(.layout-element-icon):checked { background-color: #1c71d8; border-color: #fff; }
 
 /* Strip cells: kill GTK's :checked border accent so toggled cells
  * keep the .strip-led border, not a white outline. */

--- a/data/style.css
+++ b/data/style.css
@@ -1,3 +1,8 @@
+/* ============================================================
+ * LEDSpicerUI — Legacy Fallback Styles
+ * Self-contained styling used when themes are unavailable.
+ * Hardcoded colors; superseded by style-base.css + themes.
+ * ============================================================ */
 
 combobox.noRoundLeft button.combo,
 .noRoundLeft {
@@ -69,7 +74,7 @@ combobox.noRoundRight button.combo,
 	color: #000;
 }
 
-/* BoxButton Styles */
+/* ── BoxButton Styles ─────────────────────────────────────── */
 
 .BoxButton {
 	border: 1px solid rgba(255,255,255,0.08);
@@ -108,7 +113,7 @@ combobox.noRoundRight button.combo,
 	padding: 3px 2px;
 }
 
-/* Hover effects for BoxButtons */
+/* ── Hover effects for BoxButtons ─────────────────────────── */
 
 .BoxBackgroundEdit:hover {
 	background: #72b1e8;
@@ -122,7 +127,7 @@ combobox.noRoundRight button.combo,
 	background: #f55d5d;
 }
 
-/* Area backgrounds */
+/* ── Area backgrounds ─────────────────────────────────────── */
 
 .layoutPreview {
 	background-image: url("images/layoutBackground.png");
@@ -185,7 +190,7 @@ combobox.noRoundRight button.combo,
 	background-image: url("images/backgroundProfiles.png");
 }
 
-/* BoxButton styles for different categories */
+/* ── BoxButton styles for different categories ────────────── */
 
 .DeviceBoxButton {
 	border-color: rgba(53,117,26,0.6);
@@ -214,38 +219,6 @@ combobox.noRoundRight button.combo,
 	border-color: rgba(180,120,255,1);
 }
 
-/*
-.DeviceBoxButton {
-	background-image:    url("images/deviceButtonBackground.png");
-	border-color:        #35751a;
-}
-
-.RestrictorBoxButton {
-	background-image:    url("images/restrictorButtonBackground.png");
-	border-color:        #62a0ea;
-}
-
-.ElementBoxButton {
-	background-image:    url("images/elementButtonBackground.png");
-	border-color:        #3584e4;
-}
-
-.GroupBoxButton {
-	background-image:    url("images/groupButtonBackground.png");
-	border-color:        #f9f06b;
-}
-
-.ProcessBoxButton {
-	background-image:    url("images/processButtonBackground.png");
-	border-color:        #99c1f1;
-}
-
-.InputBoxButton {
-	background-image:    url("images/profileButtonBackground.png");
-	border-color:        #3584e4;
-}
-*/
-
 .GroupBoxButton.system {
 	opacity: 0.7;
 	border-color: #9a9996;
@@ -255,12 +228,9 @@ combobox.noRoundRight button.combo,
 	opacity: 0.5;
 }
 
-/* ===========================================
- * Directory Navigator Styles
- * Add to data/style.css
- * =========================================== */
+/* ── Directory Navigator Styles ───────────────────────────── */
 
-/* Directory BoxButton - folder appearance */
+/* Directory BoxButton — folder appearance */
 .DirectoryBoxButton {
 	background-image: url("images/directoryButtonBackground.png");
 	border-color:     #f5c211;
@@ -312,7 +282,7 @@ combobox.noRoundRight button.combo,
 	opacity: 0.4;
 }
 
-/* Donation dialog */
+/* ── Donation dialog ──────────────────────────────────────── */
 
 .SupportButton {
 	color: #ffc439;

--- a/data/themes/default/dark/theme.css
+++ b/data/themes/default/dark/theme.css
@@ -1,8 +1,8 @@
-/* ============================================================
- * LEDSpicerUI — Default Dark Theme
- * Color palette and personality rules.
- * Loaded after style-base.css; overrides colors only.
- * ============================================================ */
+/*******************************************************
+ * LEDSpicerUI — Default Dark Theme                    *
+ * Color palette and personality rules.                *
+ * Loaded after style-base.css; overrides colors only. *
+ *******************************************************/
 
 /* ── Color palette ─────────────────────────────────────────── */
 
@@ -93,9 +93,7 @@ window {
 /* BoxButton — card lighter than window, with faint top highlight */
 .BoxButton {
 	border:           1px solid @color-box-border;
-	background-image: linear-gradient(180deg,
-	                    rgba(255,255,255,0.03) 0%,
-	                    rgba(255,255,255,0) 45%);
+	background-image: linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0) 45%);
 	background-color: @color-box-bg;
 	box-shadow:       inset 0 1px 0 @color-box-highlight;
 }
@@ -191,9 +189,7 @@ window {
 /* Theme selector tile */
 .ThemeTile {
 	border:           1px solid @color-box-border;
-	background-image: linear-gradient(180deg,
-	                    rgba(255,255,255,0.03) 0%,
-	                    rgba(255,255,255,0) 45%);
+	background-image: linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0) 45%);
 	background-color: @color-box-bg;
 	box-shadow:       inset 0 1px 0 @color-box-highlight;
 }
@@ -255,5 +251,5 @@ window {
 .zoneCanvas.animations    { background-image: url("backgroundAnimations.png");    }
 .zoneCanvas.profiles      { background-image: url("backgroundProfiles.png");      }
 
-.layoutPreview            { background-image: url("backgroundLayout.png");           }
+.layoutPreview            { background-image: url("backgroundLayout.png");          }
 .zoneCanvas.themes        { background-image: url("backgroundThemeSelector.png");   }

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -61,9 +61,6 @@ constexpr float DEFAULT_CHANGE_VALUE = 64.00f;
 /// Default milliseconds for solenoids and motors.
 constexpr unsigned int DEFAULT_SOLENOID  = 50;
 
-/// Milliseconds before an active LayoutElement returns to idle without further interaction.
-constexpr unsigned int LAYOUT_TIMEOUT_MS = 20000;
-
 /// Milliseconds the hardware stays lit for a single layout test command. No reset on re-click.
 constexpr unsigned int LIGHT_TIMEOUT_MS  = 1500;
 

--- a/src/Ui/DataDialogs/DialogDevice.cpp
+++ b/src/Ui/DataDialogs/DialogDevice.cpp
@@ -126,6 +126,8 @@ void DialogDevice::resetForm() noexcept {
 		btnAddElement->set_sensitive(true);
 	}
 	brief->set_text(Defaults::devicesInfo.at(name).brief);
+	// Keep DE centered on a visible parent — falls back to MW when DD is hidden (editChild path).
+	DialogElement::getInstance()->set_transient_for(is_visible() ? *this : Message::getMain());
 	DialogForm::resetForm();
 }
 
@@ -218,6 +220,18 @@ string DialogDevice::createUniqueId() const noexcept {
 
 LEDSpicerUI::Ui::Storage::Data* DialogDevice::createData(Values& rawData) const noexcept {
 	return new Storage::Device(rawData);
+}
+
+void DialogDevice::editChild(Storage::BoxButton& device, Storage::BoxButton& child) noexcept {
+	action      = Actions::EDIT;
+	clearForm();
+	currentData = device.getData();
+	wireChildrenDialogs();
+	retrieveData();
+	resetForm();
+	DialogElement::getInstance()->onEditClicked(child);
+	disconnectChildrenDialogs();
+	currentData = nullptr;
 }
 
 void DialogDevice::onEmpty() noexcept {

--- a/src/Ui/DataDialogs/DialogDevice.hpp
+++ b/src/Ui/DataDialogs/DialogDevice.hpp
@@ -50,6 +50,14 @@ public:
 	void isValid()          const          override;
 	string createUniqueId() const noexcept override;
 
+	/**
+	 * Edits a child element in place: runs DD's population pipeline so the
+	 * child dialog has fresh context, delegates to the child, no DD save.
+	 * @param device owning Device's BoxButton.
+	 * @param child  child Element's BoxButton.
+	 */
+	void editChild(Storage::BoxButton& device, Storage::BoxButton& child) noexcept;
+
 protected:
 
 	Gtk::ComboBox*   comboBoxId      = nullptr;

--- a/src/Ui/DataDialogs/DialogElement.hpp
+++ b/src/Ui/DataDialogs/DialogElement.hpp
@@ -60,6 +60,9 @@ public:
 	void isValid()          const          override;
 	string createUniqueId() const noexcept override;
 
+	/// Exposes the inherited edit entry so a parent dialog can drive an in-place edit.
+	using DialogForm::onEditClicked;
+
 	/**
 	 * Sets the current number of pins.
 	 * @param newSize

--- a/src/Ui/DialogSettings.cpp
+++ b/src/Ui/DialogSettings.cpp
@@ -151,6 +151,10 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 	builder->get_widget("BtnSettingsStyleDark",  btnStyleDark);
 	builder->get_widget("BoxSelectTheme",        flowBoxThemes);
 
+	builder->get_widget("ScaleLayoutGrid", scaleLayoutGrid);
+	for (int v {0}; v <= 100; v += 10)
+		scaleLayoutGrid->add_mark(v, Gtk::POS_BOTTOM, "");
+
 	// Sync all widgets to current Settings on every open.
 	signal_show().connect([this]() {
 		syncing = true;
@@ -164,6 +168,7 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 		switchRemoveInvalidItems->set_active(s.shouldRemoveInvalidItems());
 		switchSaveBackup->set_active(s.shouldSaveBackup());
 		switchDebugFiles->set_active(s.shouldDebugFiles());
+		scaleLayoutGrid->set_value(s.getLayoutGrid());
 		syncStyleButtons();
 		if (flowBoxThemes->get_children().empty())
 			populateThemes();
@@ -233,6 +238,17 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 	});
 	switchDebugFiles->property_active().signal_changed().connect([this]() {
 		Settings::get().setDebugFiles(switchDebugFiles->get_active());
+		commit("Settings saved");
+	});
+
+	scaleLayoutGrid->signal_change_value().connect(
+		[this](Gtk::ScrollType, double value) -> bool {
+			scaleLayoutGrid->set_value(std::round(value / 10.0) * 10.0);
+			return true;
+		}
+	);
+	scaleLayoutGrid->signal_value_changed().connect([this]() {
+		Settings::get().setLayoutGrid(static_cast<int>(scaleLayoutGrid->get_value()));
 		commit("Settings saved");
 	});
 

--- a/src/Ui/DialogSettings.hpp
+++ b/src/Ui/DialogSettings.hpp
@@ -107,6 +107,8 @@ protected:
 		* btnStyleLight = nullptr,
 		* btnStyleDark  = nullptr;
 
+	Gtk::Scale* scaleLayoutGrid = nullptr;
+
 	Gtk::FlowBox* flowBoxThemes = nullptr;
 
 	/// Guards against recursive signal firing when syncing style buttons.

--- a/src/Ui/Layout/Layout.cpp
+++ b/src/Ui/Layout/Layout.cpp
@@ -22,14 +22,29 @@
 
 #include "Layout.hpp"
 #include "Defaults.hpp"
+#include "DataDialogs/DialogDevice.hpp"
+#include "Storage/Device.hpp"
 
 using namespace LEDSpicerUI::Ui::Layout;
 using namespace LEDSpicerUI::Constants;
 
-Layout::Layout(const Glib::RefPtr<Gtk::Builder>& builder, LayoutTester* t) noexcept :
-	tester {t}
+Layout::Layout(
+	const Glib::RefPtr<Gtk::Builder>& builder,
+	LayoutTester* t,
+	Storage::BoxButtonCollection* devices
+) noexcept :
+	tester            {t},
+	devicesCollection {devices}
 {
-	builder->get_widget("LayoutBoard", board);
+	builder->get_widget_derived("LayoutBoard", board);
+	board->add_events(Gdk::BUTTON_PRESS_MASK);
+	board->signal_button_press_event().connect([this](GdkEventButton*) {
+		if (current) {
+			current->setActive(false);
+			current = nullptr;
+		}
+		return false;
+	});
 }
 
 Layout::~Layout() {
@@ -46,6 +61,7 @@ void Layout::onAdded(Storage::Element* element) noexcept {
 	placeNew(tile);
 	tile->signal_activated().connect(sigc::mem_fun(*this, &Layout::onTileActivated));
 	tile->signal_moved().connect(sigc::mem_fun(*this, &Layout::recomputeBoardSize));
+	tile->signal_editRequested().connect(sigc::mem_fun(*this, &Layout::onEditRequested));
 }
 
 void Layout::onRemoved(Storage::Element* element) noexcept {
@@ -99,4 +115,22 @@ void Layout::onTileActivated(LayoutElement* tile) noexcept {
 	if (current == tile) return;
 	if (current) current->setActive(false);
 	current = tile;
+}
+
+void Layout::onEditRequested(LayoutElement* tile) noexcept {
+	auto element {tile->getElement()};
+	auto [device, child] {resolveButtons(element)};
+	DataDialogs::DialogDevice::getInstance()->editChild(*device, *child);
+}
+
+std::pair<LEDSpicerUI::Ui::Storage::BoxButton*, LEDSpicerUI::Ui::Storage::BoxButton*>
+Layout::resolveButtons(Storage::Element* element) const noexcept {
+	for (auto device : *devicesCollection) {
+		auto elements {static_cast<Storage::Device*>(device->getData())->getChild(COLLECTION_ELEMENTS)};
+		for (auto child : *elements)
+			if (child->getData() == element)
+				return std::make_pair(device, child);
+	}
+	// Unreachable: a tile only exists for an Element owned by a Device in the collection.
+	return std::make_pair(nullptr, nullptr);
 }

--- a/src/Ui/Layout/Layout.hpp
+++ b/src/Ui/Layout/Layout.hpp
@@ -21,8 +21,10 @@
  */
 
 #include "LayoutElement.hpp"
+#include "LayoutBoard.hpp"
 #include "LayoutTester.hpp"
 #include "Storage/ElementObserver.hpp"
+#include "Storage/BoxButtonCollection.hpp"
 
 #pragma once
 
@@ -48,7 +50,11 @@ public:
 		BOARD_PAD      = 10,
 		TILE_FALLBACK_PX = 100;
 
-	Layout(const Glib::RefPtr<Gtk::Builder>& builder, LayoutTester* tester) noexcept;
+	Layout(
+		const Glib::RefPtr<Gtk::Builder>& builder,
+		LayoutTester* tester,
+		Storage::BoxButtonCollection* devicesCollection
+	) noexcept;
 
 	virtual ~Layout();
 
@@ -61,8 +67,11 @@ public:
 
 private:
 
-	Gtk::Layout*  board  = nullptr;
+	LayoutBoard*  board  = nullptr;
 	LayoutTester* tester = nullptr;
+
+	/// Points to Devices Collection to lookup the Device and Element on edit.
+	Storage::BoxButtonCollection* devicesCollection = nullptr;
 
 	std::unordered_map<Storage::Element*, LayoutElement*> tiles;
 
@@ -72,7 +81,16 @@ private:
 
 	void placeNew(LayoutElement* tile) noexcept;
 	void onTileActivated(LayoutElement* tile) noexcept;
+	void onEditRequested(LayoutElement* tile) noexcept;
 	void recomputeBoardSize() noexcept;
+
+	/**
+	 * Walks the Devices collection to find the owning Device and the Element's BoxButton.
+	 * @param element the Element to look up.
+	 * @return pair (Device BoxButton, Element BoxButton).
+	 */
+	std::pair<Storage::BoxButton*, Storage::BoxButton*>
+		resolveButtons(Storage::Element* element) const noexcept;
 };
 
 } // namespace

--- a/src/Ui/Layout/LayoutBoard.cpp
+++ b/src/Ui/Layout/LayoutBoard.cpp
@@ -1,0 +1,58 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
+/**
+ * @file      LayoutBoard.cpp
+ * @since     Jun 13, 2026
+ * @author    Patricio A. Rossi (MeduZa)
+ *
+ * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
+ *
+ * @copyright LEDSpicerUI is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright LEDSpicerUI is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * @copyright You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "LayoutBoard.hpp"
+#include "config/Settings.hpp"
+
+using namespace LEDSpicerUI::Ui::Layout;
+
+LayoutBoard::LayoutBoard(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>&) noexcept :
+	Gtk::Layout(obj)
+{
+	Config::Settings::get().onLayoutGridChanged([this]() { queue_draw(); });
+}
+
+LayoutBoard::~LayoutBoard() noexcept {
+	Config::Settings::get().onLayoutGridChanged(nullptr);
+}
+
+bool LayoutBoard::on_draw(const Cairo::RefPtr<Cairo::Context>& cr) {
+	const int g {Config::Settings::get().getLayoutGrid()};
+	if (g > 0) {
+		const auto a {get_allocation()};
+		const int w {a.get_width()}, h {a.get_height()};
+		cr->save();
+		cr->set_source_rgba(0.5, 0.5, 0.5, 0.25);
+		cr->set_line_width(1.0);
+		for (int x {0}; x < w; x += g) {
+			cr->move_to(x + 0.5, 0);
+			cr->line_to(x + 0.5, h);
+		}
+		for (int y {0}; y < h; y += g) {
+			cr->move_to(0, y + 0.5);
+			cr->line_to(w, y + 0.5);
+		}
+		cr->stroke();
+		cr->restore();
+	}
+	return Gtk::Layout::on_draw(cr);
+}

--- a/src/Ui/Layout/LayoutBoard.hpp
+++ b/src/Ui/Layout/LayoutBoard.hpp
@@ -1,0 +1,53 @@
+/* -*- Mode: C; indent-tabs-mode: t; c-basic-offset: 4; tab-width: 4 -*-  */
+/**
+ * @file      LayoutBoard.hpp
+ * @since     Jun 13, 2026
+ * @author    Patricio A. Rossi (MeduZa)
+ *
+ * @copyright Copyright © 2018 - 2026 Patricio A. Rossi (MeduZa)
+ *
+ * @copyright LEDSpicerUI is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @copyright LEDSpicerUI is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * @copyright You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtkmm/builder.h>
+#include <gtkmm/layout.h>
+
+#pragma once
+
+namespace LEDSpicerUI::Ui::Layout {
+
+/**
+ * LEDSpicerUI::Ui::Layout::LayoutBoard
+ *
+ * Gtk::Layout subclass that paints the snap grid under its children
+ * when Settings::LAYOUT_GRID is non-zero. Repaints on grid changes
+ * via Settings::onLayoutGridChanged.
+ */
+class LayoutBoard: public Gtk::Layout {
+
+public:
+
+	LayoutBoard(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>&) noexcept;
+
+	virtual ~LayoutBoard() noexcept;
+
+	LayoutBoard(const LayoutBoard&)            = delete;
+	LayoutBoard& operator=(const LayoutBoard&) = delete;
+
+protected:
+
+	bool on_draw(const Cairo::RefPtr<Cairo::Context>& cr) override;
+};
+
+} // namespace

--- a/src/Ui/Layout/LayoutElement.cpp
+++ b/src/Ui/Layout/LayoutElement.cpp
@@ -22,6 +22,7 @@
 
 #include "LayoutElement.hpp"
 #include "Defaults.hpp"
+#include "config/Settings.hpp"
 
 using namespace LEDSpicerUI::Ui::Layout;
 using namespace LEDSpicerUI::Constants;
@@ -51,7 +52,6 @@ LayoutElement::LayoutElement(Storage::Element* el, LayoutTester* t) noexcept :
 }
 
 LayoutElement::~LayoutElement() {
-	layoutTimer.disconnect();
 	lightTimer.disconnect();
 }
 
@@ -61,8 +61,7 @@ LayoutElement::Kind LayoutElement::categorize(const Storage::Element* el) noexce
 		return Kind::Strip;
 	if (v.isSet(SOLENOID))
 		return Kind::Solenoid;
-	if (v.isSet(POSITION) or v.isSet(POSITIONS) or
-	    (v.isSet(RED_PIN) and v.isSet(GREEN_PIN) and v.isSet(BLUE_PIN)))
+	if (v.isSet(POSITION) or v.isSet(POSITIONS) or (v.isSet(RED_PIN) and v.isSet(GREEN_PIN) and v.isSet(BLUE_PIN)))
 		return Kind::Rgb;
 	return Kind::Mono;
 }
@@ -71,27 +70,36 @@ void LayoutElement::build() noexcept {
 	body = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2));
 	add(*body);
 
-	nameLabel = Gtk::manage(new Gtk::Label(element->getPrimaryValue()));
-	nameLabel->set_ellipsize(Pango::ELLIPSIZE_END);
-	nameLabel->set_max_width_chars(12);
+	nameLabel = Gtk::manage(new Gtk::Label());
+	setName(element->getPrimaryValue());
 	body->pack_start(*nameLabel, Gtk::PACK_SHRINK);
 
+	auto pix {getCachedIcon(element->getValue(TYPE))};
+
 	iconImg = Gtk::manage(new Gtk::Image());
-	iconImg->set(Gdk::Pixbuf::create_from_file(
-		ICON_DIR + iconForType(element->getValue(TYPE)),
-		ICON_PX, ICON_PX, true
-	));
+	iconImg->set(pix);
 	iconImg->get_style_context()->add_class(CSS_LAYOUT_ELEMENT_ICON);
 
+	iconBtnImg = Gtk::manage(new Gtk::Image());
+	iconBtnImg->set(pix);
+	iconBtn = Gtk::manage(new Gtk::ToggleButton());
+	iconBtn->set_image(*iconBtnImg);
+	iconBtn->set_relief(Gtk::RELIEF_NONE);
+	iconBtn->set_can_focus(false);
+	iconBtn->get_style_context()->add_class(CSS_LAYOUT_ELEMENT_ICON);
+	iconBtn->signal_toggled().connect([this]() {
+		if (not iconBtn->get_active()) return; // already toggled.
+		fireAll();
+	});
+
+	rgbRow = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 2));
+	rgbRow->set_halign(Gtk::ALIGN_CENTER);
 	if (kind == Kind::Rgb or kind == Kind::Strip) {
-		rgbRow = Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 2));
-		rgbRow->set_halign(Gtk::ALIGN_CENTER);
 		auto makeTgl {[this](const char* cssClass) {
-			auto* tgl {Gtk::manage(new Gtk::ToggleButton())};
+			auto tgl {Gtk::manage(new Gtk::ToggleButton())};
 			tgl->set_can_focus(false);
 			tgl->set_size_request(RGB_TOGGLE_PX, RGB_TOGGLE_PX);
 			tgl->get_style_context()->add_class(cssClass);
-			tgl->signal_toggled().connect([this]() { touchActivity(); });
 			rgbRow->pack_start(*tgl, Gtk::PACK_SHRINK);
 			return tgl;
 		}};
@@ -100,31 +108,50 @@ void LayoutElement::build() noexcept {
 		rgbB = makeTgl(CSS_LED_B);
 	}
 
+	auto btnEdit {Gtk::manage(new Gtk::Button())};
+	btnEdit->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
+	btnEdit->set_can_focus(false);
+	btnEdit->set_relief(Gtk::RELIEF_NONE);
+	btnEdit->set_tooltip_text("Edit element");
+	btnEdit->signal_clicked().connect([this]() { editRequested.emit(this); });
+	rgbRow->pack_start(*btnEdit, Gtk::PACK_SHRINK);
+
 	if (kind == Kind::Strip) {
-		auto* iconCol {Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2))};
+		auto iconCol {Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_VERTICAL, 2))};
 		iconCol->pack_start(*iconImg, Gtk::PACK_SHRINK);
+		iconCol->pack_start(*iconBtn, Gtk::PACK_SHRINK);
 		iconCol->pack_start(*rgbRow, Gtk::PACK_SHRINK);
-		auto* iconStripRow {Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 4))};
+
+		auto iconStripRow {Gtk::manage(new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 4))};
 		iconStripRow->pack_start(*iconCol, Gtk::PACK_SHRINK);
+
 		strip = Gtk::manage(new StripRenderer());
 		strip->setCount(static_cast<uint16_t>(element->getInt(STRIPSIZE)));
 		strip->signal_led_clicked().connect([this](uint16_t firstPhysicalIdx) {
-			touchActivity();
 			fireCell(firstPhysicalIdx);
 		});
+
 		iconStripRow->pack_start(*strip, Gtk::PACK_EXPAND_WIDGET);
 		body->pack_start(*iconStripRow, Gtk::PACK_SHRINK);
 	}
 	else {
 		body->pack_start(*iconImg, Gtk::PACK_SHRINK);
-		if (rgbRow) body->pack_start(*rgbRow, Gtk::PACK_SHRINK);
+		body->pack_start(*iconBtn, Gtk::PACK_SHRINK);
+		body->pack_start(*rgbRow, Gtk::PACK_SHRINK);
 	}
 
 	show_all();
-	if (rgbRow) rgbRow->hide();
+	iconBtn->hide();
+	rgbRow->hide();
 	if (strip)  strip->hide();
 }
 
+void LayoutElement::setName(const Glib::ustring& full) noexcept {
+	const bool over {full.length() > NAME_MAX_CHARS};
+	nameLabel->set_text(over ? full.substr(0, NAME_MAX_CHARS - 1) + "…" : full);
+	if (over) nameLabel->set_tooltip_text(full);
+	else      nameLabel->set_has_tooltip(false);
+}
 
 void LayoutElement::refresh() noexcept {
 	const Kind newKind {categorize(element)};
@@ -136,11 +163,10 @@ void LayoutElement::refresh() noexcept {
 		build();
 		return;
 	}
-	nameLabel->set_text(element->getPrimaryValue());
-	iconImg->set(Gdk::Pixbuf::create_from_file(
-		ICON_DIR + iconForType(element->getValue(TYPE)),
-		ICON_PX, ICON_PX, true
-	));
+	setName(element->getPrimaryValue());
+	auto pix {getCachedIcon(element->getValue(TYPE))};
+	iconImg->set(pix);
+	iconBtnImg->set(pix);
 	if (kind == Kind::Strip) {
 		const uint16_t count {static_cast<uint16_t>(element->getInt(STRIPSIZE))};
 		if (count != strip->getCount())
@@ -157,42 +183,25 @@ void LayoutElement::setActive(bool on) noexcept {
 		if (rgbR) rgbR->set_active(false);
 		if (rgbG) rgbG->set_active(false);
 		if (rgbB) rgbB->set_active(false);
-		if (rgbRow) rgbRow->show();
+		iconImg->hide();
+		iconBtn->show();
+		rgbRow->show();
 		if (strip)  strip->show();
-		if (auto win {get_window()}) win->raise();
-		layoutTimer.disconnect();
-		layoutTimer = Glib::signal_timeout().connect(
-			sigc::mem_fun(*this, &LayoutElement::onLayoutIdle),
-			LAYOUT_TIMEOUT_MS
-		);
+		get_window()->raise();
 		activated.emit(this);
 	}
 	else {
 		ctx->remove_class(CSS_LAYOUT_ELEMENT_ACTIVE);
-		if (rgbRow) rgbRow->hide();
-		if (strip)  strip->hide();
-		layoutTimer.disconnect();
+		iconBtn->hide();
+		iconImg->show();
+		rgbRow->hide();
+		if (strip) strip->hide();
 	}
 }
 
-void LayoutElement::touchActivity() noexcept {
-	layoutTimer.disconnect();
-	layoutTimer = Glib::signal_timeout().connect(
-		sigc::mem_fun(*this, &LayoutElement::onLayoutIdle),
-		LAYOUT_TIMEOUT_MS
-	);
-}
-
-bool LayoutElement::onLayoutIdle() noexcept {
-	setActive(false);
-	return false;
-}
-
 void LayoutElement::fire(Storage::Element* target) noexcept {
-	if (lightLocked) return;
+	if (lightTimer.connected()) return;
 	const string color {resolveColorName()};
-	lightLocked = true;
-	lightTimer.disconnect();
 	lightTimer = Glib::signal_timeout().connect(
 		sigc::mem_fun(*this, &LayoutElement::onLightExpired),
 		LIGHT_TIMEOUT_MS
@@ -201,11 +210,12 @@ void LayoutElement::fire(Storage::Element* target) noexcept {
 }
 
 void LayoutElement::fireAll() noexcept {
-	if (lightLocked) return;
-	const string& color {resolveColorName()};
-	const string& colorClass {ledCssClass(color)};
-	iconImg->get_style_context()->add_class(CSS_LAYOUT_ELEMENT_FIRED);
-	iconImg->get_style_context()->add_class(colorClass);
+	if (lightTimer.connected()) return;
+	const string
+		& color {resolveColorName()},
+		& colorClass {ledCssClass(color)};
+	iconBtn->get_style_context()->add_class(CSS_LAYOUT_ELEMENT_FIRED);
+	iconBtn->get_style_context()->add_class(colorClass);
 	if (strip) {
 		const auto ledColor {colorEnumFor(color)};
 		for (uint16_t i = 0; i < strip->getCount(); i += strip->getGroupRatio())
@@ -223,12 +233,12 @@ void LayoutElement::fireCell(uint16_t firstPhysicalIdx) noexcept {
 }
 
 bool LayoutElement::onLightExpired() noexcept {
-	lightLocked = false;
 	if (not pendingTintClass.empty()) {
-		iconImg->get_style_context()->remove_class(CSS_LAYOUT_ELEMENT_FIRED);
-		iconImg->get_style_context()->remove_class(pendingTintClass);
+		iconBtn->get_style_context()->remove_class(CSS_LAYOUT_ELEMENT_FIRED);
+		iconBtn->get_style_context()->remove_class(pendingTintClass);
 		pendingTintClass.clear();
 	}
+	iconBtn->set_active(false);
 	if (strip) strip->setAllOff();
 	return false;
 }
@@ -265,22 +275,12 @@ void LayoutElement::persistPosition() noexcept {
 
 bool LayoutElement::onButtonPress(GdkEventButton* ev) noexcept {
 	if (ev->button != 1) return false;
-	pressedOnIcon = isInsideIcon(ev->x, ev->y);
-	if (active) return false;
+	if (active) return true;
 	dragging    = true;
 	dragMoved   = false;
 	dragOffsetX = ev->x;
 	dragOffsetY = ev->y;
-	return false;
-}
-
-bool LayoutElement::isInsideIcon(double x, double y) noexcept {
-	int icon_x, icon_y;
-	iconImg->translate_coordinates(*this, 0, 0, icon_x, icon_y);
-	const int
-		iw {iconImg->get_allocated_width()},
-		ih {iconImg->get_allocated_height()};
-	return x >= icon_x and x < icon_x + iw and y >= icon_y and y < icon_y + ih;
+	return true;
 }
 
 bool LayoutElement::onButtonRelease(GdkEventButton* ev) noexcept {
@@ -290,7 +290,6 @@ bool LayoutElement::onButtonRelease(GdkEventButton* ev) noexcept {
 		if (dragMoved) {
 			if (auto win {get_window()}) win->set_cursor();
 			persistPosition();
-			touchActivity();
 			return false;
 		}
 	}
@@ -298,31 +297,39 @@ bool LayoutElement::onButtonRelease(GdkEventButton* ev) noexcept {
 		setActive(true);
 		return false;
 	}
-	touchActivity();
-	if (pressedOnIcon and isInsideIcon(ev->x, ev->y))
-		fireAll();
 	return false;
 }
 
 bool LayoutElement::onMotion(GdkEventMotion* ev) noexcept {
 	if (not dragging) return false;
+
 	const double
 		dx {ev->x - dragOffsetX},
 		dy {ev->y - dragOffsetY};
 	if (not dragMoved and dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX)
 		return false;
+
 	if (not dragMoved) {
 		if (auto win {get_window()}) win->set_cursor(Gdk::Cursor::create(Gdk::FLEUR));
 	}
-	auto parent {dynamic_cast<Gtk::Layout*>(get_parent())};
-	if (not parent) return false;
+
+	auto parent {static_cast<Gtk::Layout*>(get_parent())};
 	const int
 		x  {parent->child_property_x(*this).get_value()},
 		y  {parent->child_property_y(*this).get_value()},
 		nx {static_cast<int>(x + dx)},
 		ny {static_cast<int>(y + dy)};
-	const int cx {nx < 0 ? 0 : nx}, cy {ny < 0 ? 0 : ny};
+	const auto snap {[](int v, int g) {
+		if (g <= 0) return v;
+		const int n {(v + g / 2) / g * g};
+		return std::abs(v - n) <= g / 3 ? n : v;
+	}};
+	const int
+		g  {Config::Settings::get().getLayoutGrid()},
+		cx {snap(nx < 0 ? 0 : nx, g)},
+		cy {snap(ny < 0 ? 0 : ny, g)};
 	parent->move(*this, cx, cy);
+
 	guint cw, ch;
 	parent->get_size(cw, ch);
 	const guint
@@ -365,4 +372,13 @@ StripRenderer::LedColor LayoutElement::colorEnumFor(const string& colorName) noe
 string LayoutElement::iconForType(const string& typeId) noexcept {
 	// Type id is guaranteed valid by retrieveData() repair before this is reached.
 	return "element-" + typeId + ".png";
+}
+
+Glib::RefPtr<Gdk::Pixbuf> LayoutElement::getCachedIcon(const string& typeId) noexcept {
+	static std::unordered_map<string, Glib::RefPtr<Gdk::Pixbuf>> cache;
+	auto it {cache.find(typeId)};
+	if (it != cache.end()) return it->second;
+	auto pix {Gdk::Pixbuf::create_from_file(ICON_DIR + iconForType(typeId), ICON_PX, ICON_PX, true)};
+	cache.emplace(typeId, pix);
+	return pix;
 }

--- a/src/Ui/Layout/LayoutElement.hpp
+++ b/src/Ui/Layout/LayoutElement.hpp
@@ -46,7 +46,8 @@ public:
 		ICON_PX           = 48,
 		ELEMENT_WIDTH_PX  = 96,
 		RGB_TOGGLE_PX     = 18,
-		DRAG_THRESHOLD_PX = 5;
+		DRAG_THRESHOLD_PX = 5,
+		NAME_MAX_CHARS    = 20;
 
 	LayoutElement(Storage::Element* element, LayoutTester* tester) noexcept;
 
@@ -65,11 +66,23 @@ public:
 
 	Kind getKind() const noexcept { return kind; }
 
-	/** Fired when the tile becomes active so the board can deactivate the previous one. */
+	/**
+	 * Notifies the board that this tile is now active so it can deactivate the previous one.
+	 * @return the activation signal; payload is the activated tile.
+	 */
 	sigc::signal<void, LayoutElement*>& signal_activated() noexcept { return activated; }
 
-	/** Fired after a drag persists a new position, so the board can recompute its canvas. */
+	/**
+	 * Notifies the board that this tile's position changed so it can recompute its canvas.
+	 * @return the move signal.
+	 */
 	sigc::signal<void>& signal_moved() noexcept { return moved; }
+
+	/**
+	 * Notifies the board that the user requested editing this tile's element.
+	 * @return the edit-request signal; payload is the requesting tile.
+	 */
+	sigc::signal<void, LayoutElement*>& signal_editRequested() noexcept { return editRequested; }
 
 	static Kind categorize(const Storage::Element* element) noexcept;
 
@@ -82,41 +95,45 @@ private:
 
 	Kind kind = Kind::Mono;
 
-	Gtk::Box*      body      = nullptr;
-	Gtk::Label*    nameLabel = nullptr;
-	Gtk::Image*    iconImg   = nullptr;
-	Gtk::Box*      rgbRow    = nullptr;
-	StripRenderer* strip     = nullptr;
+	Gtk::Box
+		* body   = nullptr,
+		* rgbRow = nullptr;
+
+	Gtk::Label* nameLabel = nullptr;
+
+	Gtk::Image
+		* iconImg    = nullptr,
+		* iconBtnImg = nullptr;
+
+	StripRenderer*    strip      = nullptr;
 
 	Gtk::ToggleButton
-		* rgbR = nullptr,
-		* rgbG = nullptr,
-		* rgbB = nullptr;
+		* iconBtn = nullptr,
+		* rgbR    = nullptr,
+		* rgbG    = nullptr,
+		* rgbB    = nullptr;
 
 	bool
-		active        = false,
-		dragging      = false,
-		dragMoved     = false,
-		lightLocked   = false,
-		pressedOnIcon = false;
+		active    = false,
+		dragging  = false,
+		dragMoved = false;
 
 	double
 		dragOffsetX = 0.0,
 		dragOffsetY = 0.0;
 
-	sigc::connection
-		layoutTimer,
-		lightTimer;
+	sigc::connection lightTimer;
 
 	sigc::signal<void, LayoutElement*> activated;
 	sigc::signal<void>                 moved;
+	sigc::signal<void, LayoutElement*> editRequested;
 
 	string pendingTintClass;
 
 	void build() noexcept;
+	/// Sets the tile caption, truncating past NAME_MAX_CHARS with the full name in a tooltip.
+	void setName(const Glib::ustring& full) noexcept;
 	void persistPosition() noexcept;
-	void touchActivity() noexcept;
-	bool onLayoutIdle() noexcept;
 	bool onLightExpired() noexcept;
 	void fire(Storage::Element* target) noexcept;
 	void fireAll() noexcept;
@@ -127,9 +144,8 @@ private:
 	bool onButtonRelease(GdkEventButton* ev) noexcept;
 	bool onMotion(GdkEventMotion* ev)        noexcept;
 
-	bool isInsideIcon(double x, double y) noexcept;
-
 	static string iconForType(const string& typeId) noexcept;
+	static Glib::RefPtr<Gdk::Pixbuf> getCachedIcon(const string& typeId) noexcept;
 	static const string& ledCssClass(const string& colorName) noexcept;
 	static StripRenderer::LedColor colorEnumFor(const string& colorName) noexcept;
 };

--- a/src/Ui/MainWindow.cpp
+++ b/src/Ui/MainWindow.cpp
@@ -37,7 +37,7 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 	inputNavigator(builder, this),
 	animationNavigator(builder, this),
 	profileNavigator(builder, this),
-	layout(builder, &layoutTester)
+	layout(builder, &layoutTester, &devices)
 {
 
 	Storage::Element::setObserver(&layout);

--- a/src/Ui/StatusBar.cpp
+++ b/src/Ui/StatusBar.cpp
@@ -31,22 +31,16 @@ StatusBar StatusBar::instance;
  * ellipsize the internal label — long messages must never widen the window.
  */
 void StatusBar::initialize(const Glib::RefPtr<Gtk::Builder>& builder) noexcept {
+
 	builder->get_widget("StatusBar", instance.bar);
 	instance.contextId = instance.bar->get_context_id("main");
 
-	// GtkStatusbar's message area is a GtkBox whose first child is the GtkLabel.
-	// Guard both casts in case GTK ever rearranges the widget tree.
-	if (auto* box = dynamic_cast<Gtk::Box*>(instance.bar->get_message_area())) {
-		const auto& children {box->get_children()};
-		if (not children.empty()) {
-			if (auto* label = dynamic_cast<Gtk::Label*>(children.front())) {
-				instance.label = label;
-				label->set_ellipsize(Pango::ELLIPSIZE_END);
-				label->set_hexpand(true);
-				label->set_xalign(0.0f);
-			}
-		}
-	}
+	auto box   {static_cast<Gtk::Box*>(instance.bar->get_message_area())};
+	auto label {static_cast<Gtk::Label*>(box->get_children().front())};
+	instance.label = label;
+	label->set_ellipsize(Pango::ELLIPSIZE_END);
+	label->set_hexpand(true);
+	label->set_xalign(0.0f);
 }
 
 void StatusBar::push(const string& message, Severity severity, bool persistent) noexcept {

--- a/src/config/ProfileFile.cpp
+++ b/src/config/ProfileFile.cpp
@@ -37,7 +37,7 @@ ProfileFile::ProfileFile(const string& filePath, Ui::Storage::DirectoryEntry* pa
 		profile.setValue(BACKGROUND_COLOR, DEFAULT_PROFILE_BACKGROUND_COLOR);
 
 	// Pick up the optional <transition> element so Profile's ctor can move it into its embedded record.
-	if (auto* transitionNode = getRoot()->FirstChildElement(TYPE_TRANSITION.c_str())) {
+	if (auto transitionNode {getRoot()->FirstChildElement(TYPE_TRANSITION.c_str())}) {
 		Values transitionAttrs {processNode(transitionNode)};
 		if (transitionAttrs.isSet(NAME))
 			profile.setValue(TRANSITION, transitionAttrs.getValue(NAME));

--- a/src/config/Settings.cpp
+++ b/src/config/Settings.cpp
@@ -39,6 +39,7 @@ const StringUMap Settings::DEFAULTS = {
 	{"removeInvalidItems",  HUMAN_TRUE},
 	{"saveBackup",          HUMAN_TRUE},
 	{"debugFiles",          HUMAN_FALSE},
+	{"layoutGrid",          "0"},
 };
 
 void Settings::load(const Values& raw) noexcept {

--- a/src/config/Settings.hpp
+++ b/src/config/Settings.hpp
@@ -54,7 +54,8 @@ public:
 		PRESERVE_EMPTY_DIR   {"preserveEmptyDir"},
 		REMOVE_INVALID_ITEMS {"removeInvalidItems"},
 		SAVE_BACKUP          {"saveBackup"},
-		DEBUG_FILES          {"debugFiles"};
+		DEBUG_FILES          {"debugFiles"},
+		LAYOUT_GRID          {"layoutGrid"};
 
 	/// Runtime mode — derived from binary detection result and interactiveMode preference.
 	enum class Mode {
@@ -108,6 +109,16 @@ public:
 	void setSaveBackup(bool value)         noexcept;
 	void setDebugFiles(bool value)         noexcept;
 
+	/// Layout snap-to-grid step in pixels (same on both axes). 0 = snap disabled.
+	int  getLayoutGrid() const noexcept { return getInt(LAYOUT_GRID); }
+	void setLayoutGrid(int value) noexcept {
+		setValue(LAYOUT_GRID, value);
+		if (layoutGridChanged) layoutGridChanged();
+	}
+
+	/// Register a callback fired whenever the layout grid step changes.
+	void onLayoutGridChanged(std::function<void()> cb) noexcept { layoutGridChanged = std::move(cb); }
+
 	const string& getThemeName()  const noexcept { return getValue(THEME_NAME); }
 	void setThemeName(const string& id)  noexcept { setValue(THEME_NAME, id);  }
 
@@ -154,6 +165,7 @@ protected:
 
 	StringVector colorFiles;
 	std::function<void()> colorFilesChanged;
+	std::function<void()> layoutGridChanged;
 
 	bool
 		hasGameData = false,

--- a/tests/config/SettingsTest.cpp
+++ b/tests/config/SettingsTest.cpp
@@ -50,6 +50,7 @@ TEST_F(SettingsTest, DefaultState) {
 	EXPECT_TRUE (s.shouldRemoveInvalidItems());
 	EXPECT_TRUE (s.shouldSaveBackup());
 	EXPECT_FALSE(s.shouldDebugFiles());
+	EXPECT_EQ(0, s.getLayoutGrid());
 	EXPECT_EQ(Mode::Portable, s.getMode());
 	EXPECT_TRUE(s.isPortable());
 }
@@ -67,6 +68,7 @@ TEST_F(SettingsTest, LoadAndSerialize) {
 		{"removeInvalidItems", HUMAN_FALSE},
 		{"saveBackup",         HUMAN_FALSE},
 		{"debugFiles",         HUMAN_TRUE},
+		{"layoutGrid",         "30"},
 	});
 
 	EXPECT_EQ("/usr/bin/ledspicerd",   s.getBinaryPath());
@@ -79,6 +81,7 @@ TEST_F(SettingsTest, LoadAndSerialize) {
 	EXPECT_FALSE(s.shouldRemoveInvalidItems());
 	EXPECT_FALSE(s.shouldSaveBackup());
 	EXPECT_TRUE (s.shouldDebugFiles());
+	EXPECT_EQ(30, s.getLayoutGrid());
 	EXPECT_EQ(Mode::Local, s.getMode());
 
 	// Round-trip: snapshot → reset → load → same values.
@@ -87,6 +90,7 @@ TEST_F(SettingsTest, LoadAndSerialize) {
 	s.load(snap);
 	EXPECT_EQ("/usr/bin/ledspicerd", s.getBinaryPath());
 	EXPECT_EQ(ThemeStyle::Dark,      s.getThemeStyle());
+	EXPECT_EQ(30,                    s.getLayoutGrid());
 	EXPECT_EQ(Mode::Local,           s.getMode());
 }
 
@@ -180,6 +184,26 @@ TEST_F(SettingsTest, ColorFilesChangedCallback) {
 	// Replace callback with null-equivalent (no crash on next set).
 	s.onColorFilesChanged(nullptr);
 	s.setColorFiles({"d.ini"});
+	EXPECT_EQ(2, calls);
+}
+
+TEST_F(SettingsTest, LayoutGridChangedCallback) {
+	auto& s = Settings::get();
+
+	int calls = 0;
+	s.onLayoutGridChanged([&calls]() { ++calls; });
+
+	s.setLayoutGrid(20);
+	EXPECT_EQ(20, s.getLayoutGrid());
+	EXPECT_EQ(1,  calls);
+
+	s.setLayoutGrid(0);
+	EXPECT_EQ(0, s.getLayoutGrid());
+	EXPECT_EQ(2, calls);
+
+	// Replace callback with null-equivalent (no crash on next set).
+	s.onLayoutGridChanged(nullptr);
+	s.setLayoutGrid(50);
 	EXPECT_EQ(2, calls);
 }
 


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicerUI/issues/74

- Each tile carries a pencil button (visible while active) that opens the standard Element dialog with the device context preloaded.
- `DialogDevice::editChild` runs the device dialog's population pipeline silently (no run, no save) so the child dialog inherits a fresh, fully-wired state; the device dialog itself is never shown.
- Resolution of the device and element BoxButtons is a single linear scan of the navigator's devices collection — no observer changes, no back-pointers added to data.

- Tile icon split into a passive `Gtk::Image` (inactive) and a `Gtk::ToggleButton` (active). The toggle is the fire button; the light timer untoggles it on expiry, so rapid clicks can't bypass `lightLocked`.
- Pixbufs cached per element type — each icon is loaded from disk once.
- Press on a tile is consumed locally; clicks on the empty board deselect the current tile.
- DialogElement falls back to the main window as transient parent when the device dialog is hidden, keeping the dialog centered.

- New "Layout" page in Settings with a single grid-step scale (0–100, snaps to multiples of 10, default 0 = disabled).
- `LayoutElement::onMotion` applies a magnetic snap to the configured step; free movement when the user is more than `step/3` from a gridline, snap once inside.
- New `LayoutBoard` (`Gtk::Layout` subclass) paints faint gridlines beneath the tiles and redraws live as the slider moves via a `Settings::onLayoutGridChanged` callback.

- The toggle-button styling for LED colors is now scoped with `:not(.layout-element-icon)` so the icon toggle gets its colored border/background from `.layout-element-icon-fired.led-X`, which covers all seven colors (R, G, B, Y, M, C, W). Previously Y/M/C/W fell through to default GTK styling and the toggle changed size on state changes.

address code review — hygiene and dead-code cleanup

- LayoutElement: fix onLightExpired indentation; remove dead onLayoutIdle(); static_cast the guaranteed Gtk::Layout parent in onMotion and drop the commented-out null guard; restore the informative iconForType comment; drop stray leading blank lines added to build()/fire()/onMotion().
- Layout::resolveButtons: document the trailing return as unreachable.
- style-base.css: revert comment-style churn (boxed-asterisk header and reflowed blocks) back to the house style used in theme.css; keep the functional active-tile and :not(.layout-element-icon) changes.
- Bring data/style.css in line with the house comment style used across data/ (file header, ── section dividers, em-dash minor notes); replace the boxed-asterisk Directory Navigator header. Comments only.