### PR TITLE
84: Restrictor dialog: add Test button driving the rotator binary

### DIFF
--- a/data/main.glade
+++ b/data/main.glade
@@ -5407,10 +5407,10 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
                           <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="tooltip-text" translatable="yes">When enabled, daemon test actions (lighting and clearing elements) are shown in the status bar.</property>
+                            <property name="tooltip-text" translatable="yes">When enabled, hardware test actions (lighting and clearing elements, restrictor moves) are shown in the status bar.</property>
                             <property name="spacing">5</property>
                             <child>
-                              <object class="GtkSwitch" id="SwitchSettingsDebugDaemon">
+                              <object class="GtkSwitch" id="SwitchSettingsDebugHardwareTest">
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                               </object>
@@ -5425,7 +5425,7 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label">Show daemon test actions</property>
+                                <property name="label">Show hardware test actions</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -7850,7 +7850,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkLabel" id="LabelRestrictorWays">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
@@ -7871,7 +7871,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                     <property name="selection-mode">none</property>
                     <property name="activate-on-single-click">False</property>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w2">
+                      <object class="GtkFlowBoxChild" id="2">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7889,7 +7889,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w2v">
+                      <object class="GtkFlowBoxChild" id="vertical2">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7907,7 +7907,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w4">
+                      <object class="GtkFlowBoxChild" id="4">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7925,7 +7925,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w4x">
+                      <object class="GtkFlowBoxChild" id="4x">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7943,7 +7943,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w8">
+                      <object class="GtkFlowBoxChild" id="8">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7961,7 +7961,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w16">
+                      <object class="GtkFlowBoxChild" id="16">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -7979,7 +7979,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkFlowBoxChild" id="w49">
+                      <object class="GtkFlowBoxChild" id="49">
                         <property name="width-request">64</property>
                         <property name="height-request">64</property>
                         <property name="visible">True</property>
@@ -8094,7 +8094,7 @@ If you have multiple serial devices, avoid using autodetect.</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
                     <child>
-                      <object class="GtkLabel">
+                      <object class="GtkLabel" id="LabelRestrictorMappings">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">start</property>

--- a/src/DaemonHandler.cpp
+++ b/src/DaemonHandler.cpp
@@ -59,14 +59,12 @@ bool DaemonHandler::disconnect() noexcept {
 	// Nothing to stop: skip killall (and its "no process found" stderr).
 	if (not isRunning())
 		return true;
-	string out;
-	Defaults::runCommand("killall -15 " + Glib::shell_quote(processName()), out);
+	Defaults::runCommand("killall -15 " + Glib::shell_quote(processName()));
 	return waitUntil([this] { return not isRunning(); }, STOP_TIMEOUT_MS);
 }
 
 bool DaemonHandler::isRunning() const noexcept {
-	string out;
-	return Defaults::runCommand("pidof " + Glib::shell_quote(processName()), out);
+	return Defaults::runCommand("pidof " + Glib::shell_quote(processName()));
 }
 
 bool DaemonHandler::waitUntil(const std::function<bool()>& done, int timeoutMs) const noexcept {
@@ -81,7 +79,7 @@ bool DaemonHandler::waitUntil(const std::function<bool()>& done, int timeoutMs) 
 
 bool DaemonHandler::command(Command type, std::initializer_list<string> fields) noexcept {
 	// The owner gates testing: offline drops the command, stale refreshes first.
-	if (not isReady())
+	if (not readyGate())
 		return false;
 
 	const int portNumber {std::atoi(port.c_str())};

--- a/src/DaemonHandler.hpp
+++ b/src/DaemonHandler.hpp
@@ -70,13 +70,17 @@ public:
 	bool command(Command type, std::initializer_list<string> fields) noexcept;
 
 	/**
-	 * Readiness gate the owner installs at init: command() sends only when it
-	 * returns true, letting the owner refuse testing while offline and refresh
-	 * a stale daemon first.
+	 * Installs the readiness gate: command() sends only when it returns true,
+	 * letting the owner refuse testing while offline and refresh a stale daemon
+	 * first.
+	 * @param gate predicate consulted before each send.
 	 */
-	std::function<bool()> isReady;
+	void setReadyGate(std::function<bool()> gate) noexcept { readyGate = std::move(gate); }
 
 private:
+
+	/// Readiness gate consulted by command() before each send; installed by the owner.
+	std::function<bool()> readyGate;
 
 	/// Budget and step, in ms, while waiting for the daemon to start or stop.
 	static constexpr int START_TIMEOUT_MS = 5000;

--- a/src/Defaults.cpp
+++ b/src/Defaults.cpp
@@ -262,20 +262,6 @@ const std::unordered_map<string, Defaults::TransitionInfo> Defaults::transitions
 	}},
 };
 
-const std::unordered_map<string, Defaults::Ways> Defaults::wayIds {
-	{"w2",       Ways::w2},
-	{"w2v",      Ways::w2v},
-	{"w4",       Ways::w4},
-	{"w4x",      Ways::w4x},
-	{"w8",       Ways::w8},
-	{"w16",      Ways::w16},
-	{"w49",      Ways::w49},
-	{"analog",   Ways::analog},
-	{"mouse",    Ways::mouse},
-	{"rotary8",  Ways::rotary8},
-	{"rotary12", Ways::rotary12},
-};
-
 const std::unordered_map<string, Defaults::ElementInfo> Defaults::elementsInfo = {
 	{ELEMENT_TYPE_ACTUATOR,  {"Actuator",             "Force-feedback items: solenoids, knockers, recoils, motors."}},
 	{ELEMENT_TYPE_BAR,       {"LEDs Light Strip",     "Addressable RGB strip used as a single element."}},
@@ -803,10 +789,21 @@ string Defaults::extractAfter(const string& line, const string& prefix) {
 	return result;
 }
 
+bool Defaults::runCommand(const string& command) {
+	string discard;
+	return runCommand(command, discard);
+}
+
 bool Defaults::runCommand(const string& command, string& output) {
 	try {
 		int exitStatus;
-		Glib::spawn_command_line_sync(command, &output, nullptr, &exitStatus);
+		string error;
+		Glib::spawn_command_line_sync(command, &output, &error, &exitStatus);
+		if (not error.empty()) {
+			if (not output.empty() and output.back() != '\n')
+				output += '\n';
+			output += error;
+		}
 		return (exitStatus == 0);
 	}
 	catch (const Glib::Error&) {

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -75,6 +75,9 @@ inline const string
 /// so the manual binary picker must also match this name.
 	DAEMON_BINARY {"ledspicerd"},
 
+/// Restrictor test executable; ships beside the daemon and reads the same config (restrictors section only).
+	ROTATOR_BINARY {"rotator"},
+
 /// LEDSpicer configuration file keys.
 	DEFAULT_USERID   {"1000"},
 	DEFAULT_GROUPID  {"1000"},
@@ -723,9 +726,6 @@ public:
 	 */
 	static double getLuminance(const string& color);
 
-	/// A list of all possible restrictors and rotators Ways (positions).
-	static constexpr std::array<Ways, 11> allWays{Ways::w2, Ways::w2v, Ways::w4, Ways::w4x, Ways::w8, Ways::w16, Ways::w49, Ways::analog, Ways::mouse, Ways::rotary8, Ways::rotary12};
-
 	/// A list of device to their information.
 	static const std::unordered_map<string, DeviceInfo> devicesInfo;
 
@@ -740,9 +740,6 @@ public:
 
 	/// A list of profile transition types to their information.
 	static const std::unordered_map<string, TransitionInfo> transitionsInfo;
-
-	/// A List of string names to its internal enumerated type.
-	static const std::unordered_map<string, Ways> wayIds;
 
 	/// A list of element types to their information.
 	static const std::unordered_map<string, ElementInfo> elementsInfo;
@@ -927,10 +924,17 @@ public:
 	static string extractAfter(const string& line, const string& prefix);
 
 	/**
-	 * Executes a command and captures stdout.
+	 * Executes a command, discarding its output.
 	 * @param command The command to run.
-	 * @param output Captured stdout.
-	 * @return true if command succeeded.
+	 * @return true if the command exited with status 0.
+	 */
+	static bool runCommand(const string& command);
+
+	/**
+	 * Executes a command and captures its output, with stderr appended to stdout.
+	 * @param command The command to run.
+	 * @param output Captured stdout; any stderr is appended after it.
+	 * @return true if the command exited with status 0.
 	 */
 	static bool runCommand(const string& command, string& output);
 

--- a/src/Ui/DataDialogs/DialogRestrictor.cpp
+++ b/src/Ui/DataDialogs/DialogRestrictor.cpp
@@ -21,14 +21,54 @@
  */
 
 #include "DialogRestrictor.hpp"
+#include "config/Settings.hpp"
 
 using namespace LEDSpicerUI::Ui::DataDialogs;
+using LEDSpicerUI::Defaults;
+using LEDSpicerUI::StringVector;
+
+const std::unordered_map<string, Defaults::Ways> DialogRestrictor::wayTokens {
+	{"2",         Defaults::Ways::w2},
+	{"vertical2", Defaults::Ways::w2v},
+	{"4",         Defaults::Ways::w4},
+	{"4x",        Defaults::Ways::w4x},
+	{"8",         Defaults::Ways::w8},
+	{"16",        Defaults::Ways::w16},
+	{"49",        Defaults::Ways::w49},
+	{"analog",    Defaults::Ways::analog},
+	{"mouse",     Defaults::Ways::mouse},
+	{"rotary8",   Defaults::Ways::rotary8},
+	{"rotary12",  Defaults::Ways::rotary12},
+};
+
+const string& DialogRestrictor::wayToToken(Defaults::Ways way) noexcept {
+	for (const auto& [token, w] : wayTokens)
+		if (w == way)
+			return token;
+	return emptyString;
+}
+
+StringVector DialogRestrictor::buildRotatorArgs(
+	const std::vector<std::pair<string, string>>& mappings,
+	Defaults::Ways way
+) noexcept {
+	StringVector args;
+	args.reserve(mappings.size() * 3);
+	const string& token {wayToToken(way)};
+	for (const auto& [player, joystick] : mappings) {
+		args.push_back(player);
+		args.push_back(joystick);
+		args.push_back(token);
+	}
+	return args;
+}
 
 DialogRestrictor::DialogRestrictor(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>& builder) noexcept:
 	DialogFormHost(obj, builder)
 {
 
 	registerChildDialog<DialogRestrictorMap>(builder, "DialogRestrictorMap", COLLECTION_RESTRICTOR_MAPS);
+	DialogRestrictorMap::getInstance()->setOnMapsChanged([this]() { updateWaysTestState(); });
 
 	// Register self so child dialogs can resolve the visible host window via familyToDialog.
 	familyToDialog.emplace(COLLECTION_RESTRICTORS, this);
@@ -51,6 +91,8 @@ DialogRestrictor::DialogRestrictor(BaseObjectType* obj, const Glib::RefPtr<Gtk::
 	builder->get_widget("InputRestrictorSpeedOn",       speedOn);
 	builder->get_widget("InputRestrictorSpeedOff",      speedOff);
 	builder->get_widget("BriefRestrictor",              brief);
+	builder->get_widget("LabelRestrictorWays",          waysLabel);
+	builder->get_widget("LabelRestrictorMappings",      mappingsLabel);
 	builder->get_widget("BtnAddRestrictorMap",          btnAddRestrictorMap);
 
 
@@ -61,12 +103,18 @@ DialogRestrictor::DialogRestrictor(BaseObjectType* obj, const Glib::RefPtr<Gtk::
 	idListstore = static_cast<Gtk::ListStore*>(builder->get_object("liststoreRestrictorsId").get());
 
 	// Restrictor Icons.
-	for (auto& w : Defaults::wayIds) {
+	for (auto& w : wayTokens) {
 		Gtk::FlowBoxChild* i;
 		builder->get_widget(w.first, i);
 		i->hide();
 		waysIcons.emplace(w.second, i);
 	}
+
+	// Way icons are also the test toggle group (single active, none allowed).
+	builder->get_widget("FlowboxWays", flowboxWays);
+	flowboxWays->signal_child_activated().connect(
+		sigc::mem_fun(*this, &DialogRestrictor::onWayActivated)
+	);
 
 	selectorCombo->signal_changed().connect([this]() {
 		string newName{selectorCombo->get_active_id()};
@@ -125,6 +173,7 @@ void DialogRestrictor::resetForm() noexcept {
 	btnAddRestrictorMap->set_sensitive(
 		DialogRestrictorMap::getInstance()->getSize() < Defaults::restrictorsInfo.at(selectorCombo->get_active_id()).interfaces
 	);
+	updateWaysTestState();
 	DialogForm::resetForm();
 }
 
@@ -258,8 +307,8 @@ void DialogRestrictor::onEmpty() noexcept {
 	speedOn->set_value(GZ40_DEFAULT_SPEED);
 	speedOff->set_value(GZ40_DEFAULT_SPEED);
 
-	for (auto& w : Defaults::allWays) {
-		waysIcons.at(w)->hide();
+	for (auto& [way, child] : waysIcons) {
+		child->hide();
 	}
 	brief->set_label("");
 	btnApply->set_sensitive(false);
@@ -288,4 +337,90 @@ void DialogRestrictor::onSelected() noexcept {
 	const uint8_t newInterfaces {Defaults::restrictorsInfo.at(name).interfaces};
 	if (Defaults::restrictorsInfo.at(previousName).interfaces > newInterfaces)
 		DialogRestrictorMap::getInstance()->trimToInterfaces(newInterfaces);
+}
+
+void DialogRestrictor::updateWaysTestState() noexcept {
+	const bool live {
+		Config::Settings::get().isInteractive()
+		and testLive and testLive()
+		and DialogRestrictorMap::getInstance()->getSize() > 0
+	};
+	selectedWay = nullptr;
+	flowboxWays->unselect_all();
+	flowboxWays->set_selection_mode(live ? Gtk::SELECTION_SINGLE : Gtk::SELECTION_NONE);
+	flowboxWays->set_activate_on_single_click(live);
+	// Portable: informational. Otherwise sensitive only when live.
+	flowboxWays->set_sensitive(live or Config::Settings::get().isPortable());
+
+	// Narrowing: multi-interface restrictor with 2+ mappings, while live.
+	const string name {selectorCombo->get_active_id()};
+	const bool multi {
+		live
+		and Defaults::isMulti(name)
+		and DialogRestrictorMap::getInstance()->getSize() >= 2
+	};
+	auto mapsBox {DialogRestrictorMap::getInstance()->getBox()};
+	mapsBox->unselect_all();
+	mapsBox->set_selection_mode(multi ? Gtk::SELECTION_MULTIPLE : Gtk::SELECTION_NONE);
+
+	// Selection mode re-enables child focus; these groups are mouse-driven.
+	for (auto child : flowboxWays->get_children())
+		child->set_can_focus(false);
+	for (auto child : mapsBox->get_children())
+		child->set_can_focus(false);
+
+	waysLabel->set_text(live
+		? "Click a direction or rotation to test the hardware"
+		: "Supported directions and rotations");
+	mappingsLabel->set_text(multi
+		? "Player mappings — select rows to scope the test (none tests all)"
+		: "Player mappings");
+}
+
+void DialogRestrictor::onWayActivated(Gtk::FlowBoxChild* child) noexcept {
+	if (rotatorRunning)
+		return;
+	// Re-click clears the toggle; sends nothing.
+	if (child == selectedWay) {
+		flowboxWays->unselect_all();
+		selectedWay = nullptr;
+		return;
+	}
+	flowboxWays->select_child(*child);
+	selectedWay = child;
+
+	if (not rotatorRunner)
+		return;
+
+	// Resolve the toggled way from its icon.
+	Defaults::Ways way {Defaults::Ways::invalid};
+	for (const auto& [w, icon] : waysIcons)
+		if (icon == child) {
+			way = w;
+			break;
+		}
+
+	// Scope: selected mappings, else all (none == all).
+	std::vector<std::pair<string, string>> mappings;
+	const auto selected {DialogRestrictorMap::getInstance()->getBox()->get_selected_children()};
+	if (not selected.empty())
+		for (auto child : selected) {
+			auto data {static_cast<Storage::BoxButton*>(child)->getData()};
+			mappings.emplace_back(data->getValue(PLAYER), data->getValue(JOYSTICK));
+		}
+	else if (auto maps {getChildCollection(COLLECTION_RESTRICTOR_MAPS)})
+		for (auto bb : *maps)
+			mappings.emplace_back(bb->getData()->getValue(PLAYER), bb->getData()->getValue(JOYSTICK));
+
+	rotatorRunning = true;
+	string output;
+	const bool ok {rotatorRunner(buildRotatorArgs(mappings, way), output)};
+	rotatorRunning = false;
+
+	if (ok) {
+		if (Config::Settings::get().shouldDebugHardwareTest() and not output.empty())
+			StatusBar::getInstance().push(output, StatusBar::Severity::Debug);
+	}
+	else if (not output.empty())
+		StatusBar::getInstance().push(output, StatusBar::Severity::Error);
 }

--- a/src/Ui/DataDialogs/DialogRestrictor.hpp
+++ b/src/Ui/DataDialogs/DialogRestrictor.hpp
@@ -48,6 +48,15 @@ public:
 	void isValid()          const          override;
 	string createUniqueId() const noexcept override;
 
+	void setRotatorRunner(std::function<bool(const StringVector&, string&)> fn) noexcept { rotatorRunner = std::move(fn); }
+	void setTestLive(std::function<bool()> fn) noexcept { testLive = std::move(fn); }
+
+	/**
+	 * Re-evaluates the way-icon test affordance: the three modes, the live
+	 * test toggle, and whether the restrictor has any player mappings.
+	 */
+	void updateWaysTestState() noexcept;
+
 protected:
 
 	Gtk::ComboBox* comboBoxId = nullptr;
@@ -64,11 +73,48 @@ protected:
 	/// Restrictor ways icon map keyed by Ways enum value.
 	std::unordered_map<Defaults::Ways, Gtk::FlowBoxChild*> waysIcons;
 
+	/// Rotator CLI ways token to its internal Defaults::Ways type (also the way-icon glade ids).
+	static const std::unordered_map<string, Defaults::Ways> wayTokens;
+
+	/**
+	 * @param way
+	 * @return the rotator CLI token for a way (e.g. Ways::w2v -> "vertical2"), or empty if invalid.
+	 */
+	static const string& wayToToken(Defaults::Ways way) noexcept;
+
+	/**
+	 * Builds the positional rotator arguments to set player mappings to one way.
+	 * @param mappings player/joystick number pairs to include in the test.
+	 * @param way the requested way.
+	 * @return flat token list, three per mapping: <player> <joystick> <ways>.
+	 */
+	static StringVector buildRotatorArgs(
+		const std::vector<std::pair<string, string>>& mappings,
+		Defaults::Ways way
+	) noexcept;
+
 	Gtk::ListStore* idListstore = nullptr;
 
 	Gtk::Label* brief = nullptr;
 
+	/// Section labels that gain a test hint when the test affordance is active.
+	Gtk::Label
+		* waysLabel     = nullptr,
+		* mappingsLabel = nullptr;
+
 	Gtk::Button* btnAddRestrictorMap = nullptr;
+
+	/// Restrictor way-icon test group (one toggle per supported way).
+	Gtk::FlowBox* flowboxWays = nullptr;
+	/// Currently toggled way, or null when none.
+	Gtk::FlowBoxChild* selectedWay = nullptr;
+	/// Guards re-entrancy while a rotator run is in flight.
+	bool rotatorRunning = false;
+
+	/// Runs the rotator with positional args; true on a clean exit (set by MainWindow).
+	std::function<bool(const StringVector&, string&)> rotatorRunner;
+	/// True when a rotator test may run now: interactive, connected, fresh (set by MainWindow).
+	std::function<bool()> testLive;
 
 	DialogRestrictor(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>& builder) noexcept;
 
@@ -78,6 +124,13 @@ protected:
 
 	void onEmpty()    noexcept override;
 	void onSelected() noexcept override;
+
+	/**
+	 * Runs (or clears) the rotator test for the toggled way over all the
+	 * restrictor's player mappings.
+	 * @param child the activated way icon.
+	 */
+	void onWayActivated(Gtk::FlowBoxChild* child) noexcept;
 
 };
 

--- a/src/Ui/DataDialogs/DialogRestrictorMap.cpp
+++ b/src/Ui/DataDialogs/DialogRestrictorMap.cpp
@@ -159,10 +159,12 @@ void DialogRestrictorMap::trimToInterfaces(uint8_t maxInterfaces) noexcept {
 void DialogRestrictorMap::afterCreate(Storage::BoxButton&) noexcept {
 	// This is necessary to disable the add if needed.
 	btnAdd->set_sensitive(checkAvailableInterfaces());
+	if (onMapsChanged) onMapsChanged();
 }
 
 void DialogRestrictorMap::afterDeleteConfirmation(Storage::BoxButton& boxButton) noexcept {
 	DialogForm::afterDeleteConfirmation(boxButton);
 	// Assume that after deleting we can add a new map
 	btnAdd->set_sensitive(true);
+	if (onMapsChanged) onMapsChanged();
 }

--- a/src/Ui/DataDialogs/DialogRestrictorMap.hpp
+++ b/src/Ui/DataDialogs/DialogRestrictorMap.hpp
@@ -55,6 +55,12 @@ public:
 	 */
 	void trimToInterfaces(uint8_t maxInterfaces) noexcept;
 
+	/**
+	 * Installs a callback fired when a mapping is added or removed.
+	 * @param cb the observer (e.g. the host re-evaluating its test affordance).
+	 */
+	void setOnMapsChanged(std::function<void()> cb) noexcept { onMapsChanged = std::move(cb); }
+
 protected:
 
 	Gtk::Button* btnAdd = nullptr;
@@ -67,6 +73,9 @@ protected:
 		* comboBoxRestrictors = nullptr;
 
 	Gtk::ListStore* liststoreRestrictorMapId = nullptr;
+
+	/// Fired after a mapping add/remove; lets the host re-gate without a back-reference.
+	std::function<void()> onMapsChanged;
 
 	DialogRestrictorMap(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>& builder) noexcept;
 

--- a/src/Ui/DialogSettings.cpp
+++ b/src/Ui/DialogSettings.cpp
@@ -156,7 +156,7 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 	builder->get_widget("SwitchSettingsRemoveInvalidItems", switchRemoveInvalidItems);
 	builder->get_widget("SwitchSettingsSaveBackup",         switchSaveBackup);
 	builder->get_widget("SwitchSettingsDebugFiles",         switchDebugFiles);
-	builder->get_widget("SwitchSettingsDebugDaemon",        switchDebugDaemon);
+	builder->get_widget("SwitchSettingsDebugHardwareTest",  switchDebugHardwareTest);
 
 	builder->get_widget("BtnSettingsStyleAuto",  btnStyleAuto);
 	builder->get_widget("BtnSettingsStyleLight", btnStyleLight);
@@ -184,7 +184,7 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 		switchRemoveInvalidItems->set_active(s.shouldRemoveInvalidItems());
 		switchSaveBackup->set_active(s.shouldSaveBackup());
 		switchDebugFiles->set_active(s.shouldDebugFiles());
-		switchDebugDaemon->set_active(s.shouldDebugDaemon());
+		switchDebugHardwareTest->set_active(s.shouldDebugHardwareTest());
 		scaleLayoutGrid->set_value(s.getLayoutGrid());
 		spinLayoutTestTimeout->set_value(s.getLayoutTestTimeout() / 1000.0);
 		syncStyleButtons();
@@ -279,8 +279,8 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 		Settings::get().setDebugFiles(switchDebugFiles->get_active());
 		commit(savedMessage);
 	});
-	switchDebugDaemon->property_active().signal_changed().connect([this]() {
-		Settings::get().setDebugDaemon(switchDebugDaemon->get_active());
+	switchDebugHardwareTest->property_active().signal_changed().connect([this]() {
+		Settings::get().setDebugHardwareTest(switchDebugHardwareTest->get_active());
 		commit(savedMessage);
 	});
 

--- a/src/Ui/DialogSettings.hpp
+++ b/src/Ui/DialogSettings.hpp
@@ -111,7 +111,7 @@ protected:
 		* switchRemoveInvalidItems = nullptr,
 		* switchSaveBackup         = nullptr,
 		* switchDebugFiles         = nullptr,
-		* switchDebugDaemon        = nullptr;
+		* switchDebugHardwareTest  = nullptr;
 
 	Gtk::ToggleButton
 		* btnStyleAuto  = nullptr,

--- a/src/Ui/Layout/LayoutElement.cpp
+++ b/src/Ui/Layout/LayoutElement.cpp
@@ -230,7 +230,7 @@ void LayoutElement::fireAll() noexcept {
 	if (strip)
 		strip->setAll(colorEnumFor(color));
 	pendingTintClass = colorClass;
-	debugDaemon((strip ? "Lighting strip " : "Lighting ") + element->getPrimaryValue() + ' ' + color);
+	debugHardwareTest((strip ? "Lighting strip " : "Lighting ") + element->getPrimaryValue() + ' ' + color);
 	fire(element);
 }
 
@@ -242,7 +242,7 @@ void LayoutElement::fireCell(uint16_t firstPhysicalIdx) noexcept {
 	// dropped (e.g. testing paused mid-group for a daemon refresh).
 	const auto children {element->copyStripChildren()};
 	const uint16_t groupSize {strip->getGroupSize(firstPhysicalIdx)};
-	debugDaemon("Lighting " + std::to_string(groupSize) + " LEDs " + color);
+	debugHardwareTest("Lighting " + std::to_string(groupSize) + " LEDs " + color);
 	for (uint16_t i {0}; i < groupSize; ++i)
 		if (not lightTarget(children[firstPhysicalIdx + i], color))
 			break;
@@ -252,7 +252,7 @@ void LayoutElement::clearCell(uint16_t firstPhysicalIdx) noexcept {
 	// Clear the same elements the pack lit.
 	const auto children {element->copyStripChildren()};
 	const uint16_t groupSize {strip->getGroupSize(firstPhysicalIdx)};
-	debugDaemon("Clearing " + std::to_string(groupSize) + " LEDs");
+	debugHardwareTest("Clearing " + std::to_string(groupSize) + " LEDs");
 	for (uint16_t i {0}; i < groupSize; ++i)
 		if (not clearTarget(children[firstPhysicalIdx + i]))
 			break;
@@ -282,13 +282,13 @@ bool LayoutElement::onLightExpired() noexcept {
 	}
 	iconBtn->set_active(false);
 	if (strip) strip->setAllOff();
-	debugDaemon((strip ? "Clearing strip " : "Clearing ") + element->getPrimaryValue());
+	debugHardwareTest((strip ? "Clearing strip " : "Clearing ") + element->getPrimaryValue());
 	clearTarget(element);
 	return false;
 }
 
-void LayoutElement::debugDaemon(const string& message) noexcept {
-	if (Config::Settings::get().shouldDebugDaemon())
+void LayoutElement::debugHardwareTest(const string& message) noexcept {
+	if (Config::Settings::get().shouldDebugHardwareTest())
 		StatusBar::getInstance().push(message, StatusBar::Severity::Debug);
 }
 

--- a/src/Ui/Layout/LayoutElement.hpp
+++ b/src/Ui/Layout/LayoutElement.hpp
@@ -169,9 +169,9 @@ private:
 	bool clearTarget(Storage::Element* target) noexcept;
 
 	/**
-	 * Pushes a daemon test action to the status bar when daemon debug is on.
+	 * Pushes a hardware test action to the status bar when hardware-test debug is on.
 	 */
-	void debugDaemon(const string& message) noexcept;
+	void debugHardwareTest(const string& message) noexcept;
 	const string& resolveColorName() const noexcept;
 
 	bool onButtonPress(GdkEventButton* ev)   noexcept;

--- a/src/Ui/MainWindow.cpp
+++ b/src/Ui/MainWindow.cpp
@@ -109,15 +109,25 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 		updateDaemonControls();
 	});
 
-	// Daemon-relevant changes (devices, elements, groups, port) stale the test daemon.
+	// Config changes stale the staged config; restrictors are included for the rotator test.
 	auto staleDaemon {[this]() { onDaemonConfigChanged(); }};
-	CollectionHandler::getInstance(COLLECTION_DEVICES )->onChange(staleDaemon);
-	CollectionHandler::getInstance(COLLECTION_ELEMENTS)->onChange(staleDaemon);
-	CollectionHandler::getInstance(COLLECTION_GROUPS  )->onChange(staleDaemon);
+	CollectionHandler::getInstance(COLLECTION_DEVICES    )->onChange(staleDaemon);
+	CollectionHandler::getInstance(COLLECTION_ELEMENTS   )->onChange(staleDaemon);
+	CollectionHandler::getInstance(COLLECTION_GROUPS     )->onChange(staleDaemon);
+	CollectionHandler::getInstance(COLLECTION_RESTRICTORS)->onChange(staleDaemon);
 	inputPortNumber->signal_changed().connect(staleDaemon);
 
 	// command() asks this before every send; we refresh a stale daemon first.
-	DaemonHandler::getInstance().isReady = [this]() { return ensureDaemonReady(); };
+	DaemonHandler::getInstance().setReadyGate([this]() { return ensureDaemonReady(); });
+
+	// Rotator test reuses the readiness gate.
+	DialogRestrictor::getInstance()->setRotatorRunner(
+		[this](const StringVector& args, string& output) { return runRotatorTest(args, output); }
+	);
+	// runRotatorTest refreshes a stale config, so gate only on interactive + connected.
+	DialogRestrictor::getInstance()->setTestLive([this]() {
+		return Settings::get().isInteractive() and toggleConnect->get_active();
+	});
 
 	// Top directory information.
 	Gtk::HeaderBar* header;
@@ -490,7 +500,7 @@ bool MainWindow::connectDaemon() noexcept {
 	}
 	hideBusy();
 	if (ok) {
-		Settings::get().setDaemonStale(false);
+		Settings::get().setConfigDirty(false);
 		layout.setTesting(true);
 		StatusBar::getInstance().push("Daemon connected", StatusBar::Severity::Success);
 		return true;
@@ -511,7 +521,7 @@ bool MainWindow::ensureDaemonReady() noexcept {
 		return false;
 	// Live, but the base configuration drifted: redeploy it and cancel this test
 	// (the tile was paused mid-fire); the user reactivates to test the fresh daemon.
-	if (Settings::get().isDaemonStale()) {
+	if (Settings::get().isConfigDirty()) {
 		reconnectDaemon();
 		return false;
 	}
@@ -535,7 +545,7 @@ bool MainWindow::reconnectDaemon() noexcept {
 	}
 	hideBusy();
 	if (ok) {
-		Settings::get().setDaemonStale(false);
+		Settings::get().setConfigDirty(false);
 		layout.setTesting(true);   // resume consumers on the fresh daemon
 		return true;
 	}
@@ -548,6 +558,23 @@ bool MainWindow::reconnectDaemon() noexcept {
 		StatusBar::Severity::Warning
 	);
 	return false;
+}
+
+bool MainWindow::runRotatorTest(const StringVector& positional, string& output) noexcept {
+	if (not ensureDaemonReady())
+		return false;
+	const string rotator {
+		(std::filesystem::path(Settings::get().getBinaryPath()).parent_path() / ROTATOR_BINARY).string()
+	};
+	if (not std::filesystem::exists(rotator)) {
+		output = "Rotator binary not found next to the daemon.";
+		return false;
+	}
+	return Defaults::runCommand(
+		Glib::shell_quote(rotator) + " -c " + Glib::shell_quote(sandbox->getConfigPath())
+			+ " " + Defaults::implode(positional, ' '),
+		output
+	);
 }
 
 void MainWindow::showBusy(const Glib::ustring& text) noexcept {
@@ -588,8 +615,8 @@ void MainWindow::updateDaemonControls() noexcept {
 void MainWindow::onDaemonConfigChanged() noexcept {
 	// Element/port changes re-evaluate the toggle; data drift stales a live daemon.
 	updateDaemonControls();
-	if (toggleConnect->get_active() and not Settings::get().isDaemonStale()) {
-		Settings::get().setDaemonStale(true);
+	if (toggleConnect->get_active() and not Settings::get().isConfigDirty()) {
+		Settings::get().setConfigDirty(true);
 		StatusBar::getInstance().push(
 			"Base configuration changed — the daemon will refresh on your next test.",
 			StatusBar::Severity::Info

--- a/src/Ui/MainWindow.hpp
+++ b/src/Ui/MainWindow.hpp
@@ -173,6 +173,14 @@ protected:
 	bool reconnectDaemon() noexcept;
 
 	/**
+	 * Stages the config and runs the rotator with positional player/joystick/ways args.
+	 * @param positional flat token list passed after `rotator -c <conf>`.
+	 * @param output     captured rotator output (stdout with stderr appended).
+	 * @return true if the rotator ran and exited cleanly.
+	 */
+	bool runRotatorTest(const StringVector& positional, string& output) noexcept;
+
+	/**
 	 * Shows/enables the connect toggle per mode (hidden/disabled/enabled).
 	 */
 	void updateDaemonControls() noexcept;

--- a/src/Ui/Storage/readme.md
+++ b/src/Ui/Storage/readme.md
@@ -213,7 +213,7 @@ The registration is automatically released when the `Parent` is destroyed.
 
 ```cpp
 StringUMap extra{{COLOR, "Red"}};
-auto* link = new Storage::Link(extra, linkKey, linkType, linkFields, target);
+auto link = new Storage::Link(extra, linkKey, linkType, linkFields, target);
 ```
 
 - `linkKey` — field name used to identify the target in XML (e.g. `NAME`).

--- a/src/config/Settings.cpp
+++ b/src/config/Settings.cpp
@@ -105,7 +105,7 @@ void Settings::setPreserveEmptyDir(bool value)   noexcept { setValue(PRESERVE_EM
 void Settings::setRemoveInvalidItems(bool value) noexcept { setValue(REMOVE_INVALID_ITEMS, value); }
 void Settings::setSaveBackup(bool value)         noexcept { setValue(SAVE_BACKUP,          value); }
 void Settings::setDebugFiles(bool value)         noexcept { setValue(DEBUG_FILES,          value); }
-void Settings::setDebugDaemon(bool value)        noexcept { setValue(DEBUG_DAEMON,         value); }
+void Settings::setDebugHardwareTest(bool value)  noexcept { setValue(DEBUG_HARDWARE_TEST,  value); }
 
 unsigned Settings::getLayoutTestTimeout() const noexcept {
 	return static_cast<unsigned>(std::lround(getDouble(LAYOUT_TEST_TIMEOUT) * 1000));

--- a/src/config/Settings.hpp
+++ b/src/config/Settings.hpp
@@ -55,7 +55,7 @@ public:
 		REMOVE_INVALID_ITEMS {"removeInvalidItems"},
 		SAVE_BACKUP          {"saveBackup"},
 		DEBUG_FILES          {"debugFiles"},
-		DEBUG_DAEMON         {"debugDaemon"},
+		DEBUG_HARDWARE_TEST  {"debugHardwareTest"},
 		LAYOUT_GRID          {"layoutGrid"},
 		LAYOUT_TEST_TIMEOUT  {"layoutTestTimeout"};
 
@@ -99,7 +99,7 @@ public:
 	 */
 	string getThemePath() const noexcept;
 
-	void setBinaryPath(const string& path)     noexcept; ///< Also recomputes currentMode.
+	void setBinaryPath(const string& path)     noexcept; // Also recomputes currentMode.
 	void setDataDir(const string& dir)         noexcept;
 	void setThemePath(const string& dir)       noexcept;
 	void setProjectsDir(const string& dir)     noexcept;
@@ -110,29 +110,38 @@ public:
 	bool shouldRemoveInvalidItems() const noexcept { return is(REMOVE_INVALID_ITEMS); }
 	bool shouldSaveBackup()         const noexcept { return is(SAVE_BACKUP);          }
 	bool shouldDebugFiles()         const noexcept { return is(DEBUG_FILES);          }
-	bool shouldDebugDaemon()        const noexcept { return is(DEBUG_DAEMON);         }
+	bool shouldDebugHardwareTest()  const noexcept { return is(DEBUG_HARDWARE_TEST);  }
 
-	void setInteractiveMode(bool value)    noexcept; ///< Also recomputes currentMode.
+	void setInteractiveMode(bool value)    noexcept; // Also recomputes currentMode.
 	void setPreserveEmptyDir(bool value)   noexcept;
 	void setRemoveInvalidItems(bool value) noexcept;
 	void setSaveBackup(bool value)         noexcept;
 	void setDebugFiles(bool value)         noexcept;
-	void setDebugDaemon(bool value)        noexcept;
+	void setDebugHardwareTest(bool value)  noexcept;
 
-	/// Layout snap-to-grid step in pixels (same on both axes). 0 = snap disabled.
-	int  getLayoutGrid() const noexcept { return getInt(LAYOUT_GRID); }
+	/**
+	 * @return Layout snap-to-grid step in pixels (same on both axes). 0 = snap disabled.
+	 */
+	int getLayoutGrid() const noexcept { return getInt(LAYOUT_GRID); }
 	void setLayoutGrid(int value) noexcept {
 		setValue(LAYOUT_GRID, value);
 		if (layoutGridChanged) layoutGridChanged();
 	}
 
-	/// Register a callback fired whenever the layout grid step changes.
+	/**
+	 * Register a callback fired whenever the layout grid step changes.
+	 * @param cb
+	 */
 	void onLayoutGridChanged(std::function<void()> cb) noexcept { layoutGridChanged = std::move(cb); }
 
-	/// Layout test light duration, in milliseconds. Stored as seconds (1 decimal); read on demand.
+	/**
+	 * Layout test light duration, in milliseconds. Stored as seconds (1 decimal); read on demand.
+	 */
 	unsigned getLayoutTestTimeout() const noexcept;
-	/// @param seconds duration in seconds; persisted with a single decimal.
-	void     setLayoutTestTimeout(double seconds) noexcept;
+	/**
+	 * @param seconds duration in seconds; persisted with a single decimal.
+	 */
+	void setLayoutTestTimeout(double seconds) noexcept;
 
 	const string& getThemeName()  const noexcept { return getValue(THEME_NAME); }
 	void setThemeName(const string& id)  noexcept { setValue(THEME_NAME, id);  }
@@ -145,9 +154,11 @@ public:
 	bool isLocal()      const noexcept { return currentMode == Mode::Local;       }
 	bool isInteractive() const noexcept { return currentMode == Mode::Interactive; }
 
-	/// Runtime flag: the connected test daemon's config no longer matches the live data.
-	bool isDaemonStale()      const noexcept { return daemonStale;  }
-	void setDaemonStale(bool value) noexcept { daemonStale = value; }
+	/**
+	 * Runtime flag: the staged config no longer matches the live data and must be redeployed.
+	 */
+	bool isConfigDirty()      const noexcept { return configDirty;  }
+	void setConfigDirty(bool value) noexcept { configDirty = value; }
 
 	const string&       getConfigPath()     const noexcept { return configPath;     }
 	const string&       getCurrentProject() const noexcept { return currentProject; }
@@ -157,26 +168,33 @@ public:
 	bool getHasControls() const noexcept { return hasControls; }
 
 	void setConfigPath(const string& path)     noexcept;
-	void setCurrentProject(const string& name) noexcept; ///< Also writes DEFAULT_PROJECT.
-	void setColorFiles(StringVector files)     noexcept; ///< Also calls colorFilesChanged if set.
+	void setCurrentProject(const string& name) noexcept; // Also writes DEFAULT_PROJECT.
+	void setColorFiles(StringVector files)     noexcept; // Also calls colorFilesChanged if set.
 
-	/// Register a callback fired whenever the color file list is replaced.
+	/**
+	 * Register a callback fired whenever the color file list is replaced.
+	 * @param cb
+	 */
 	void onColorFilesChanged(std::function<void()> cb) noexcept { colorFilesChanged = std::move(cb); }
 
 	void setDataDirStatus(bool gameData, bool colors, bool controls) noexcept;
 
-	/// projectsDir + currentProject + "/", or empty if either is unset.
+	/**
+	 * projectsDir + currentProject + "/", or empty if either is unset.
+	 */
 	string getProjectDir() const noexcept;
 
-	/// Portable: getProjectDir() + CONFIG_FILE.  Local/Interactive: configPath.
+	/**
+	 * Portable: getProjectDir() + CONFIG_FILE.  Local/Interactive: configPath.
+	 */
 	string getActiveConfigPath() const noexcept;
 
 protected:
 
 	Mode currentMode = Mode::Portable;
 
-	/// True when a connected test daemon needs a refresh to match edited data.
-	bool daemonStale = false;
+	/// True when the staged config needs a refresh to match edited data.
+	bool configDirty = false;
 
 	string
 		configPath,
@@ -199,7 +217,9 @@ private:
 	static const StringUMap DEFAULTS;
 	static Settings instance;
 
-	/// Derives currentMode from binaryPath (empty → Portable) and interactiveMode.
+	/**
+	 * Derives currentMode from binaryPath (empty → Portable) and interactiveMode.
+	 */
 	void updateMode() noexcept;
 };
 


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicerUI/issues/84

Adds a Test affordance to the Restrictor dialog that drives the `rotator`
binary so users can validate restrictor wiring without the command line.

- The way icons become a single-active toggle group (none allowed, re-click
  clears, never assumes hardware position). Toggling a way runs `rotator -c <sandbox.conf> <player> <joystick> <ways> …` for the restrictor's
  player mappings.
- Three modes drive the affordance: **portable** (icons informational), **local** (disabled hint), **interactive + connected** (live).
- Staging reuses the daemon sandbox + `ensureDaemonReady()`; restrictor edits
  now stale the staged config so the test re-stages fresh data.
- Multi-interface restrictors with 2+ mappings can scope the test to selected
  rows (none selected == all).
- Output goes to the status bar: stdout only when "debug hardware test" is on,
  red on a non-zero exit or stderr.

- `Settings`: `debugDaemon` → `debugHardwareTest`, `daemonStale` → `configDirty`.
- `Defaults::runCommand`: output-less overload + stderr folded into output.
- Way tokens aligned to rotator's CLI vocabulary; `Ways` stays in `Defaults`,
  the way-token map + arg builder live in `DialogRestrictor`.
- `DaemonHandler` readiness gate installed via a setter.

- `RestrictorTest`/`DefaultsTest` updated; full suite green (27/27).
- Verified on hardware.