### PR TITLE
85: Test mode for restrictor-only configs

### DIFF
--- a/data/main.glade
+++ b/data/main.glade
@@ -2065,7 +2065,7 @@ If nothing is set, the default is 1000ms.</property>
             <property name="sensitive">False</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
-            <property name="tooltip-text" translatable="yes">Connect to the LEDSpicer daemon</property>
+            <property name="tooltip-text" translatable="yes">Enable test mode — layout testing for devices and rotation testing for restrictors</property>
             <child>
               <object class="GtkImage">
                 <property name="visible">True</property>

--- a/src/Ui/MainWindow.cpp
+++ b/src/Ui/MainWindow.cpp
@@ -444,11 +444,11 @@ void MainWindow::onConnectToggled() {
 		}
 	}
 	else {
-		showBusy("Disconnecting…");
+		showBusy("Stopping…");
 		DaemonHandler::getInstance().disconnect();
 		layout.setTesting(false);
 		hideBusy();
-		StatusBar::getInstance().push("Daemon disconnected", StatusBar::Severity::Info);
+		StatusBar::getInstance().push("Test mode off", StatusBar::Severity::Info);
 	}
 }
 
@@ -480,7 +480,11 @@ void MainWindow::syncSandbox() noexcept {
 }
 
 bool MainWindow::launchDaemon() {
+	// Always stage the shared sandbox config; both zones read it.
 	sandbox->regenerate(packLedspicerConfig(), devices, restrictors, groups);
+	// Daemon zone: ledspicerd runs only when there are devices to drive.
+	if (CollectionHandler::getInstance(COLLECTION_DEVICES)->getSize() == 0)
+		return true;
 	return DaemonHandler::getInstance().connect(
 		sandbox->getConfigPath(), sandbox->getProjectsDir(), inputPortNumber->get_text()
 	);
@@ -489,7 +493,8 @@ bool MainWindow::launchDaemon() {
 bool MainWindow::connectDaemon() noexcept {
 	if (not sandbox)
 		return false;
-	showBusy("Connecting…");
+	const bool daemon {CollectionHandler::getInstance(COLLECTION_DEVICES)->getSize() > 0};
+	showBusy(daemon ? "Connecting…" : "Staging…");
 	bool ok {false};
 	string error;
 	try {
@@ -501,8 +506,13 @@ bool MainWindow::connectDaemon() noexcept {
 	hideBusy();
 	if (ok) {
 		Settings::get().setConfigDirty(false);
-		layout.setTesting(true);
-		StatusBar::getInstance().push("Daemon connected", StatusBar::Severity::Success);
+		// Layout consumers only make sense against a live daemon.
+		if (daemon)
+			layout.setTesting(true);
+		StatusBar::getInstance().push(
+			daemon ? "Daemon connected" : "Test mode ready",
+			StatusBar::Severity::Success
+		);
 		return true;
 	}
 	StatusBar::getInstance().push(
@@ -546,7 +556,9 @@ bool MainWindow::reconnectDaemon() noexcept {
 	hideBusy();
 	if (ok) {
 		Settings::get().setConfigDirty(false);
-		layout.setTesting(true);   // resume consumers on the fresh daemon
+		// Resume consumers only when a daemon is actually live (devices present).
+		if (CollectionHandler::getInstance(COLLECTION_DEVICES)->getSize() > 0)
+			layout.setTesting(true);
 		return true;
 	}
 	// Could not refresh: stay paused, drop the link and reflect it on the toggle.
@@ -591,24 +603,28 @@ void MainWindow::hideBusy() noexcept {
 }
 
 void MainWindow::updateDaemonControls() noexcept {
-	// A test can only run in interactive mode, with a port and at least one element.
+	// Daemon zone needs devices + port; restrictor zone needs only restrictors.
+	// Enabled in interactive mode when either zone has data.
+	const bool
+		hasDevices {CollectionHandler::getInstance(COLLECTION_DEVICES)->getSize() > 0},
+		hasRestrictors {CollectionHandler::getInstance(COLLECTION_RESTRICTORS)->getSize() > 0},
+		portOk {not inputPortNumber->get_text().empty()};
 	const bool eligible {
 		Settings::get().isInteractive()
-		and not inputPortNumber->get_text().empty()
-		and CollectionHandler::getInstance(COLLECTION_ELEMENTS)->getSize() > 0
+		and ((hasDevices and portOk) or hasRestrictors)
 	};
 	// Hidden on portable; visible otherwise, enabled only when a test can run.
 	toggleConnect->set_visible(not Settings::get().isPortable());
 	toggleConnect->set_sensitive(eligible);
 
-	// A live daemon whose project drifted out of eligibility must drop.
+	// A live test session whose project drifted out of eligibility must drop.
 	if (not eligible and toggleConnect->get_active()) {
 		DaemonHandler::getInstance().disconnect();
 		layout.setTesting(false);
 		ignoreConnectToggle = true;
 		toggleConnect->set_active(false);
 		ignoreConnectToggle = false;
-		StatusBar::getInstance().push("Daemon disconnected", StatusBar::Severity::Info);
+		StatusBar::getInstance().push("Test mode off", StatusBar::Severity::Info);
 	}
 }
 
@@ -618,7 +634,7 @@ void MainWindow::onDaemonConfigChanged() noexcept {
 	if (toggleConnect->get_active() and not Settings::get().isConfigDirty()) {
 		Settings::get().setConfigDirty(true);
 		StatusBar::getInstance().push(
-			"Base configuration changed — the daemon will refresh on your next test.",
+			"Base configuration changed — it will refresh on your next test.",
 			StatusBar::Severity::Info
 		);
 	}

--- a/src/Ui/MainWindow.hpp
+++ b/src/Ui/MainWindow.hpp
@@ -146,8 +146,8 @@ protected:
 	void syncSandbox() noexcept;
 
 	/**
-	 * Regenerates the test config and launches the daemon.
-	 * @return true once our daemon is up.
+	 * Stages the shared test config; launches the daemon only when devices are present.
+	 * @return true once staged (and, with devices, the daemon is up).
 	 * @throws Message if the config cannot be written.
 	 */
 	bool launchDaemon();
@@ -186,8 +186,8 @@ protected:
 	void updateDaemonControls() noexcept;
 
 	/**
-	 * Stales the test daemon when daemon-relevant data (devices, elements,
-	 * groups, port) changes, so it refreshes on the next test.
+	 * Stales the staged test config when test-relevant data (devices, elements,
+	 * groups, restrictors, port) changes, so it refreshes on the next test.
 	 */
 	void onDaemonConfigChanged() noexcept;
 


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicerUI/issues/85

The test toggle was gated on LED elements, meaning a restrictor-only project (no LED hardware) could never enter test mode, leaving the rotator test unreachable.

Reframe the single toggle as a shared sandbox configuration with two zones: the daemon zone (devices, layout test) and the restrictor zone (rotator test). Test mode is available when either zone contains data; staging is always performed, while ledspicerd launches only when devices are present.

- updateDaemonControls: Eligibility is now based on (devices and port) OR restrictors. The port requirement applies exclusively to the daemon zone.
- launchDaemon: Always stage the sandbox configuration; connect the daemon only when devices exist.
- connectDaemon/reconnectDaemon: Drive layout consumers and the "Daemon connected" status exclusively for the daemon zone.
- Relabel the toggle tooltip and status messages to remove daemon-specific wording.