### PR TITLE
88: Fix empty UI when a project is opened under a different mode

### DIFF
--- a/src/Defaults.cpp
+++ b/src/Defaults.cpp
@@ -645,6 +645,17 @@ string Defaults::tab() {
 	return tabs;
 }
 
+bool Defaults::comboBoxHasId(Gtk::ComboBox* comboBox, const string& id) {
+	auto model {comboBox->get_model()};
+	const int idColumn {comboBox->get_id_column()};
+	for (const auto& row : model->children()) {
+		Glib::ustring rowId;
+		row.get_value(idColumn, rowId);
+		if (rowId.raw() == id) return true;
+	}
+	return false;
+}
+
 void Defaults::populateComboBoxTextWithNumbers(Gtk::ComboBoxText* comboBox, int from, int to, const StringVector& ignoreList) {
 	comboBox->remove_all();
 	for (int c = from; c <= to; c++) {

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -833,6 +833,13 @@ public:
 	);
 
 	/**
+	 * @param comboBox
+	 * @param id
+	 * @return true if the combo already contains a row with this id.
+	 */
+	static bool comboBoxHasId(Gtk::ComboBox* comboBox, const string& id);
+
+	/**
 	 * Cleans and populates a combobox with IDs and mark used elements.
 	 * @param store the ListStore with to fill
 	 * @param max the maximum ID
@@ -899,6 +906,11 @@ public:
 	 * @param state True to ignore changes, false otherwise.
 	 */
 	static void setIgnoreChanges(bool state);
+
+	/**
+	 * @return true if change tracking is currently suppressed.
+	 */
+	static bool isIgnoringChanges() noexcept { return ignoreChanges; }
 
 	/**
 	 * Appends a numeric index to duplicate display labels in a StringMap.

--- a/src/Ui/DialogProject.cpp
+++ b/src/Ui/DialogProject.cpp
@@ -46,21 +46,23 @@ DialogProject::DialogProject(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> con
 
 	// Select project button
 	comboSelectProject->signal_changed().connect([this]() {
-		const string name{comboSelectProject->get_active_id()};
+		const string name {comboSelectProject->get_active_id()};
 		if (name.empty()) {
 			boxNewProjectName->set_visible(true);
 			inputNewProjectName->set_text("");
 			inputNewProjectName->grab_focus();
-			btnApply->set_sensitive(false);
-			return;
 		}
-		boxNewProjectName->set_visible(false);
-		setProjectName(name);
+		else {
+			boxNewProjectName->set_visible(false);
+			projectName = name;
+		}
+		refreshApplyState();
 	});
 
 	Defaults::attachFilenameFilter(inputNewProjectName);
 	inputNewProjectName->signal_changed().connect([this]() {
-		setProjectName(string(inputNewProjectName->get_text()));
+		projectName = inputNewProjectName->get_text().raw();
+		refreshApplyState();
 	});
 
 	// Dialog show
@@ -101,7 +103,9 @@ void DialogProject::scanProjects() {
 		Message::displayError(e.what(), this);
 	}
 
-	StringVector projects;
+	// Transient: collected only to sort before populating the combo, which is the
+	// single source of truth for the project list.
+	StringVector names;
 	Glib::RefPtr<Gio::FileInfo> fileInfo;
 	while ((fileInfo = enumerator->next_file())) {
 		if (fileInfo->get_file_type() != Gio::FILE_TYPE_DIRECTORY) continue;
@@ -111,14 +115,13 @@ void DialogProject::scanProjects() {
 		if (name.size() > BACKUP_SUFFIX.size() and
 			name.compare(name.size() - BACKUP_SUFFIX.size(), BACKUP_SUFFIX.size(), BACKUP_SUFFIX) == 0)
 			continue;
-		projects.push_back(name);
+		names.push_back(name);
 	}
 
-	std::sort(projects.begin(), projects.end());
+	std::sort(names.begin(), names.end());
 
-	for (const auto& project : projects) {
-		comboSelectProject->append(project, project);
-	}
+	for (const auto& name : names)
+		comboSelectProject->append(name, name);
 }
 
 void DialogProject::setProjectsDir(const string& projectsDir, bool setFileProjectsDirSelector) {
@@ -136,12 +139,44 @@ void DialogProject::setProjectsDir(const string& projectsDir, bool setFileProjec
 	updateBoxProjectActions();
 }
 
-void DialogProject::setProjectName(const string& projectName) {
-	this->projectName = projectName;
-	btnApply->set_sensitive(not this->projectName.empty());
+void DialogProject::updateBoxProjectActions() {
+	refreshApplyState();
+	boxProjectActions->show_all();
 }
 
-void DialogProject::updateBoxProjectActions() {
-	btnApply->set_sensitive(not projectName.empty());
-	boxProjectActions->show_all();
+void DialogProject::checkNewName(const string& name) const {
+	if (Settings::get().getProjectsDir().empty())
+		throw Message("Set a projects directory first.");
+	// Reserved by the save transaction for backups.
+	if (name.size() >= BACKUP_SUFFIX.size()
+		and name.compare(name.size() - BACKUP_SUFFIX.size(), BACKUP_SUFFIX.size(), BACKUP_SUFFIX) == 0)
+		throw Message("Names ending in \"" + BACKUP_SUFFIX + "\" are reserved.");
+	if (Defaults::comboBoxHasId(comboSelectProject, name))
+		throw Message("A project with that name already exists.");
+}
+
+void DialogProject::refreshApplyState() {
+	// An existing project chosen in the combo is always valid.
+	if (not comboSelectProject->get_active_id().empty()) {
+		inputNewProjectName->unset_icon(Gtk::ENTRY_ICON_SECONDARY);
+		btnApply->set_sensitive(true);
+		return;
+	}
+	const string name {inputNewProjectName->get_text()};
+	if (name.empty()) {
+		inputNewProjectName->unset_icon(Gtk::ENTRY_ICON_SECONDARY);
+		btnApply->set_sensitive(false);
+		return;
+	}
+	// New project: validate the typed name, flagging it inline on failure.
+	try {
+		checkNewName(name);
+		inputNewProjectName->unset_icon(Gtk::ENTRY_ICON_SECONDARY);
+		btnApply->set_sensitive(true);
+	}
+	catch (Message& e) {
+		inputNewProjectName->set_icon_from_icon_name("dialog-error", Gtk::ENTRY_ICON_SECONDARY);
+		inputNewProjectName->set_icon_tooltip_text(e.takeMessage(), Gtk::ENTRY_ICON_SECONDARY);
+		btnApply->set_sensitive(false);
+	}
 }

--- a/src/Ui/DialogProject.hpp
+++ b/src/Ui/DialogProject.hpp
@@ -41,7 +41,6 @@ public:
 	const string& getProjectName() const;
 
 	void setProjectsDir(const string& projectsDir, bool setFileProjectsDirSelector);
-	void setProjectName(const string& projectName);
 
 	/**
 	 * Scans projectsDir for available projects.
@@ -75,6 +74,18 @@ protected:
 	 * Activate open/select project if projects and data dirs are set.
 	 */
 	void updateBoxProjectActions();
+
+	/**
+	 * Validates a candidate new-project name.
+	 * @param name candidate name
+	 * @throws Message if the projects directory is unset, the name is reserved, or it exists.
+	 */
+	void checkNewName(const string& name) const;
+
+	/**
+	 * Sets Apply sensitivity and the name-entry error icon for the current selection.
+	 */
+	void refreshApplyState();
 
 };
 

--- a/src/Ui/MainWindow.cpp
+++ b/src/Ui/MainWindow.cpp
@@ -140,6 +140,15 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 	// Save project
 	btnSaveProject->signal_clicked().connect([this]() {
 		try {
+			// Saving under the wrong mode would write the config to the other mode's
+			// location and duplicate it; block until the mode matches the project.
+			if (not projectMatchesMode(Settings::get().getCurrentProject())) {
+				const auto [appMode, projectMode] {Settings::getModeLabels(Settings::get().getMode())};
+				throw Message(
+					"This project was created for " + projectMode + " mode, but the application is running in "
+					+ appMode + " mode.\nSwitch back to " + projectMode + " mode to save it."
+				);
+			}
 			if (boxRandomColors->get_children().size() == 1) {
 				throw Message("The number of random colors need to be more than one or none.");
 			}
@@ -387,19 +396,45 @@ LEDSpicerUI::Values MainWindow::packLedspicerConfig() const noexcept {
 	return r;
 }
 
+bool MainWindow::projectMatchesMode(const string& name) const noexcept {
+	const string projectDir {Settings::get().getProjectsDir() + name + '/'};
+	// A new project (no directory yet) adopts the current mode on its first save.
+	if (not Glib::file_test(projectDir, Glib::FileTest::FILE_TEST_IS_DIR))
+		return true;
+	const bool portableProject {Glib::file_test(projectDir + CONFIG_FILE, Glib::FileTest::FILE_TEST_EXISTS)};
+	return portableProject == Settings::get().isPortable();
+}
+
 void MainWindow::openProject(const string& name) {
+
+	// Opening a project under the wrong mode reads the wrong config location; refuse
+	// before touching state.
+	if (not projectMatchesMode(name)) {
+		const auto [appMode, projectMode] {Settings::getModeLabels(Settings::get().getMode())};
+		Message::displayError(
+			"Unable to open project \"" + name + "\" because it was created for " + projectMode + " mode.\n"
+			"The application is currently running in " + appMode + " mode. Please switch modes to open this project.",
+			this
+		);
+		return;
+	}
+
 	Settings::get().setCurrentProject(name);
 	Defaults::setSubtitle(name);
 	comboColors->set_active_id("");
 
 	Message::beginBatch();
+	bool loadFailed {false};
 	try {
 		readConfigFile(Settings::get().getActiveConfigPath(), true, IMPORT_ALL);
 		DialogSettings::getInstance()->saveSettings();
 	}
 	catch (Message& e) {
-		if (Glib::file_test(Settings::get().getActiveConfigPath(), Glib::FileTest::FILE_TEST_EXISTS))
+		// A present but unreadable config is a real failure; an absent one is a new project.
+		if (Glib::file_test(Settings::get().getActiveConfigPath(), Glib::FileTest::FILE_TEST_EXISTS)) {
 			Message::collect(XMLHelper::cleanError("The config file raised an error: " + e.takeMessage()));
+			loadFailed = true;
+		}
 		// Order mirrors the destructor (dependents before sources).
 		profileNavigator.clear();
 		animationNavigator.clear();
@@ -417,9 +452,19 @@ void MainWindow::openProject(const string& name) {
 	DialogRestrictor::getInstance()->refreshItems();
 	DialogProcess::getInstance()->refreshItems();
 	Defaults::cleanDirty();
-	mainTabs->set_visible_child("configuration");
-	mainTabsBox->set_sensitive(true);
-	btnImportConfig->set_sensitive(true);
+
+	if (loadFailed) {
+		// Bad project: stay out of it, leave the UI idle.
+		Settings::get().setCurrentProject("");
+		Defaults::setSubtitle("");
+		mainTabsBox->set_sensitive(false);
+		btnImportConfig->set_sensitive(false);
+	}
+	else {
+		mainTabs->set_visible_child("configuration");
+		mainTabsBox->set_sensitive(true);
+		btnImportConfig->set_sensitive(true);
+	}
 
 	// Drop any previous test connection; this project's config is built on connect.
 	DaemonHandler::getInstance().disconnect();
@@ -429,7 +474,7 @@ void MainWindow::openProject(const string& name) {
 	ignoreConnectToggle = false;
 	updateDaemonControls();
 
-	Message::finishBatch("Project loaded");
+	Message::finishBatch(loadFailed ? "Project could not be loaded" : "Project loaded");
 }
 
 void MainWindow::onConnectToggled() {
@@ -688,10 +733,14 @@ void MainWindow::readConfigFile(const string& dataFilePath, bool wipe, uint8_t i
 }
 
 void MainWindow::populateColorsCombo() {
+	// Programmatic refresh, not a user edit: don't let it mark the project dirty.
+	const bool prev {Defaults::isIgnoringChanges()};
+	Defaults::setIgnoreChanges(true);
 	const string active = comboColors->get_active_id();
 	comboColors->remove_all();
 	for (const auto& c : Settings::get().getColorFiles())
 		comboColors->append(c, c);
 	if (not active.empty())
 		comboColors->set_active_id(active);
+	Defaults::setIgnoreChanges(prev);
 }

--- a/src/Ui/MainWindow.hpp
+++ b/src/Ui/MainWindow.hpp
@@ -215,6 +215,14 @@ protected:
 	void openProject(const string& name);
 
 	/**
+	 * Whether a project's on-disk origin is compatible with the current mode.
+	 * A new project (no directory yet) adopts the current mode.
+	 * @param name project directory name
+	 * @return true if it may be opened or saved now.
+	 */
+	bool projectMatchesMode(const string& name) const noexcept;
+
+	/**
 	 * Reads a ledspicer.conf file.
 	 * @param ledspicerconf
 	 * @param wipe if true, will clean before importing.

--- a/src/config/Settings.hpp
+++ b/src/config/Settings.hpp
@@ -149,10 +149,20 @@ public:
 	ThemeStyle getThemeStyle()           const noexcept;
 	void       setThemeStyle(ThemeStyle) noexcept;
 
-	Mode getMode()      const noexcept { return currentMode;                      }
-	bool isPortable()   const noexcept { return currentMode == Mode::Portable;    }
-	bool isLocal()      const noexcept { return currentMode == Mode::Local;       }
+	Mode getMode()      const noexcept  { return currentMode;                      }
+	bool isPortable()   const noexcept  { return currentMode == Mode::Portable;    }
+	bool isLocal()      const noexcept  { return currentMode == Mode::Local;       }
 	bool isInteractive() const noexcept { return currentMode == Mode::Interactive; }
+
+	/**
+	 * @param mode
+	 * @return the two main modes, sorted by the passed mode.
+	 */
+	static std::pair<string, string> getModeLabels(Mode mode) noexcept {
+		// Local and Interactive share the non-portable "Local" label.
+		if (mode == Mode::Portable) return {"Portable", "Local"};
+		return {"Local", "Portable"};
+	}
 
 	/**
 	 * Runtime flag: the staged config no longer matches the live data and must be redeployed.


### PR DESCRIPTION
## Summary
Opening a project while the app's execution mode differs from the mode the
project was created in left the UI responsive with the project name in the
title bar but no devices, inputs, animations, or profiles, and no error.
## Root cause
Settings::getActiveConfigPath() resolves ledspicer.conf to a mode-dependent
location (system path for Local/Interactive, projectDir/ledspicer.conf for
Portable). A project saved under one mode was read from the wrong location
under the other, so ConfigFile threw (MainWindow.cpp:645) and openProject's
catch silently wiped every collection while still enabling the tabs.
## Changes
- Origin guard: a project's mode is derived from disk; opening or saving it
  under a mismatching mode is refused with a message, before any state change.
- Graceful failure: an unreadable/corrupt config reports the error and leaves
  the UI idle instead of showing an empty, editable project.
- New-project validation: Apply requires a projects directory, a unique name,
  and a non-reserved ".bak" suffix, with an inline error on the name entry.
- Add read-only Defaults::comboBoxHasId (no set_active_id state-change probe).
- Add Settings::getModeLabels for the mismatch messages.
- Fix a stray dirty flag / active Save with no project (color-combo refresh).
## Testing
Built clean; manually verified: Local project opened in Portable (and vice
versa) is refused with the message; corrupt config lands idle; new-project
name validation for empty projects dir, duplicate, and ".bak"; mid-session
mode switch blocks save instead of duplicating the config.
## Related
Follow-ups tracked separately: #89 (restrictor-only save validation),
#91 (restrictor-only load), #90 (migration / read-only config).
Closes #88