### PR TITLE
90: Migration tool + react to read-only project config

### DIFF
--- a/data/main.glade
+++ b/data/main.glade
@@ -255,6 +255,9 @@ Author: Patricio A Rossi
                         <property name="vexpand">True</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedConfig"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="margin-start">2</property>
@@ -636,6 +639,9 @@ You can reduce that list by adding only the colors you want to be used by Random
                         </child>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedConfig"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="margin-start">2</property>
@@ -944,6 +950,9 @@ Very useful when MAME does not provide game's data, or when you want to customiz
                             <property name="orientation">vertical</property>
                             <child>
                               <object class="GtkBox">
+                                <style>
+                                  <class name="RoLockedConfig"/>
+                                </style>
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
                                 <child>
@@ -1111,6 +1120,9 @@ If nothing is set, the default is 1000ms.</property>
                         <property name="spacing">5</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedConfig"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -1200,6 +1212,9 @@ If nothing is set, the default is 1000ms.</property>
                         <property name="spacing">5</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedConfig"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -1334,6 +1349,9 @@ If nothing is set, the default is 1000ms.</property>
                     </child>
                     <child>
                       <object class="GtkBox">
+                        <style>
+                          <class name="RoLockedConfig"/>
+                        </style>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
@@ -1499,6 +1517,9 @@ If nothing is set, the default is 1000ms.</property>
                     </child>
                     <child>
                       <object class="GtkBox">
+                        <style>
+                          <class name="RoLockedProject"/>
+                        </style>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
@@ -1686,6 +1707,9 @@ If nothing is set, the default is 1000ms.</property>
                     </child>
                     <child>
                       <object class="GtkBox">
+                        <style>
+                          <class name="RoLockedProject"/>
+                        </style>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
@@ -1869,6 +1893,9 @@ If nothing is set, the default is 1000ms.</property>
                     </child>
                     <child>
                       <object class="GtkBox">
+                        <style>
+                          <class name="RoLockedProject"/>
+                        </style>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
@@ -2125,6 +2152,9 @@ If nothing is set, the default is 1000ms.</property>
         </child>
         <child>
           <object class="GtkButton" id="BtnImportConfig">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
@@ -2386,6 +2416,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">2</property>
@@ -2438,6 +2471,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -2828,6 +2864,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
             <property name="spacing">5</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
@@ -2940,6 +2979,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
                 <property name="spacing">2</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedConfig"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -3589,6 +3631,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
             <property name="spacing">2</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -3709,6 +3754,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedProject"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="spacing">5</property>
@@ -3866,6 +3914,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedProject"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -3973,6 +4024,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedProject"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -4066,6 +4120,9 @@ Compatible with version @MINIMUM_COMPATIBILITY@+</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkBox">
+                            <style>
+                              <class name="RoLockedProject"/>
+                            </style>
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <child>
@@ -4385,11 +4442,77 @@ Autodetected if ledspicerd is detected</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkToggleButton" id="ToggleNewProjectPortable">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text">Stores ledspicer.conf inside the project directory instead of the system location</property>
+                    <property name="label">Portable</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="BoxProjectConvert">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="spacing">5</property>
+                <property name="margin-top">10</property>
+                <child>
+                  <object class="GtkButton" id="BtnProjectMakePortable">
+                    <property name="label">Make portable</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text">Copy the system configuration into the project directory</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="BtnProjectDeploy">
+                    <property name="label">Deploy to system</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text">Copy the project configuration over the system one, keeping a backup</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="BtnProjectUseSystem">
+                    <property name="label">Use system config</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text">Stop using the embedded configuration, keeping it as a backup</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>
@@ -5623,6 +5746,9 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
@@ -5847,6 +5973,9 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
             <property name="spacing">2</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -5891,6 +6020,9 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -5993,6 +6125,9 @@ Ships empty; place theme folders here, or point this anywhere you keep them.</pr
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -6083,6 +6218,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -6357,6 +6495,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
@@ -6427,6 +6568,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkNotebook" id="NotebookDeviceConnections">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <child>
@@ -7074,6 +7218,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkScrolledWindow" id="ScrolledWindowConnections">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="hadjustment">adjustmentMainWindowScrolledWindowsH</property>
@@ -7114,6 +7261,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -7338,6 +7488,9 @@ Default: 100%.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxLinkEditColor">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
             <child>
@@ -7377,6 +7530,9 @@ Default: 100%.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxLinkEditCombo">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
             <child>
@@ -7533,6 +7689,9 @@ Default: 100%.</property>
             <property name="spacing">2</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -7578,6 +7737,9 @@ Default: 100%.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">2</property>
@@ -7680,6 +7842,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
@@ -7777,6 +7942,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -7807,6 +7975,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedConfig"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -8090,6 +8261,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedConfig"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -8233,6 +8407,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8287,6 +8464,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8339,6 +8519,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedConfig"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8449,6 +8632,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8598,6 +8784,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8675,6 +8864,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -8787,6 +8979,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">10</property>
@@ -8872,6 +9067,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="homogeneous">True</property>
@@ -8998,6 +9196,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
@@ -9096,6 +9297,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxActorAudio">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
@@ -9348,6 +9552,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxActorGradient">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -9429,6 +9636,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             <property name="spacing">2</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <child>
@@ -9545,6 +9755,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedProject"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
@@ -9640,6 +9853,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxActorSerpentine">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">2</property>
@@ -9780,6 +9996,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
         </child>
         <child>
           <object class="GtkBox" id="BoxActorFileReader">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <child>
@@ -9872,6 +10091,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             <property name="spacing">5</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -9972,6 +10194,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedProject"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -10064,6 +10289,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedProject"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -10157,6 +10385,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedProject"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -10245,6 +10476,9 @@ If you have multiple serial devices, avoid using autodetect.</property>
             </child>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -10397,6 +10631,9 @@ False: the element or group will stay ON.</property>
             </child>
             <child>
               <object class="GtkBox" id="BoxInputCreditsSettings">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="spacing">5</property>
@@ -10620,6 +10857,9 @@ Multi will blink the next start</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -10856,6 +11096,9 @@ Multi will blink the next start</property>
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
@@ -11153,6 +11396,9 @@ you can set the same trigger multiple time on different maps but only the last o
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkBox">
+                <style>
+                  <class name="RoLockedProject"/>
+                </style>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="tooltip-text" translatable="yes">Select a source from the list or type one manually.</property>
@@ -11212,6 +11458,9 @@ you can set the same trigger multiple time on different maps but only the last o
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox">
+                    <style>
+                      <class name="RoLockedProject"/>
+                    </style>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="spacing">5</property>
@@ -11349,6 +11598,9 @@ you can set the same trigger multiple time on different maps but only the last o
         </child>
         <child>
           <object class="GtkBox">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
@@ -11395,6 +11647,9 @@ you can set the same trigger multiple time on different maps but only the last o
         </child>
         <child>
           <object class="GtkBox" id="BoxTransitionSpeed">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
             <child>
@@ -11440,6 +11695,9 @@ you can set the same trigger multiple time on different maps but only the last o
         </child>
         <child>
           <object class="GtkBox" id="BoxTransitionColor">
+            <style>
+              <class name="RoLockedProject"/>
+            </style>
             <property name="can-focus">False</property>
             <property name="spacing">5</property>
             <child>

--- a/src/Defaults.cpp
+++ b/src/Defaults.cpp
@@ -594,6 +594,41 @@ void Defaults::initialize(Gtk::HeaderBar* header, Gtk::Button* btnSave) {
 	btnSave->set_sensitive(false);
 }
 
+void Defaults::sweepWritability(Gtk::Widget* widget, const string& cssClass, bool writable) noexcept {
+
+	auto context {widget->get_style_context()};
+	if (context->has_class(cssClass)) {
+		// Marked edit buttons flip to view buttons instead of locking.
+		if (context->has_class(CSS_RO_VIEW)) {
+			auto button {static_cast<Gtk::Button*>(widget)};
+			button->set_image_from_icon_name(writable ? ICON_EDIT : ICON_VIEW, Gtk::ICON_SIZE_BUTTON);
+			// Swap the leading verb, keeping any trailing subject.
+			const string tooltip {button->get_tooltip_text()};
+			const auto subject {tooltip.find(' ')};
+			button->set_tooltip_text(
+				(writable ? "Edit" : "View") + (subject == string::npos ? "" : tooltip.substr(subject))
+			);
+			return;
+		}
+		widget->set_sensitive(writable);
+		return;
+	}
+
+	if (auto container {dynamic_cast<Gtk::Container*>(widget)}; container)
+		for (auto child : container->get_children())
+			sweepWritability(child, cssClass, writable);
+}
+
+void Defaults::applyWritability(const string& cssClass, bool writable) noexcept {
+	for (auto window : Gtk::Window::list_toplevels())
+		sweepWritability(window, cssClass, writable);
+}
+
+void Defaults::applyWritability(Gtk::Widget* widget, bool configWritable, bool projectWritable) noexcept {
+	sweepWritability(widget, CSS_RO_LOCKED_CONFIG,  configWritable);
+	sweepWritability(widget, CSS_RO_LOCKED_PROJECT, projectWritable);
+}
+
 void Defaults::registerWidget(Gtk::Editable* widget) {
 	widget->signal_changed().connect(&Defaults::markDirty);
 }
@@ -627,8 +662,9 @@ void Defaults::cleanDirty() {
 	btnSave->set_sensitive(false);
 }
 
-void Defaults::setSubtitle(const string& text) {
+void Defaults::setSubtitle(const string& text, const string& tooltip) {
 	header->set_subtitle(text);
+	header->set_tooltip_text(tooltip);
 }
 
 void Defaults::increaseTab() {

--- a/src/Defaults.hpp
+++ b/src/Defaults.hpp
@@ -407,6 +407,12 @@ inline const string
 #define ICON_DELETE "edit-delete-symbolic"
 #define ICON_EDIT   "emblem-system-symbolic"
 #define ICON_TRASH  "user-trash-symbolic"
+#define ICON_VIEW   "view-reveal-symbolic"
+
+// Writability markers (see Defaults::applyWritability).
+#define CSS_RO_LOCKED_CONFIG  "RoLockedConfig"  // Locks when the root config source is read-only.
+#define CSS_RO_LOCKED_PROJECT "RoLockedProject" // Locks when the project directory is read-only.
+#define CSS_RO_VIEW           "RoView"          // Edit buttons that flip to a view button instead of locking.
 
 // Layout
 #define CSS_LAYOUT_ELEMENT        "layout-element"
@@ -766,6 +772,25 @@ public:
 	static void initialize(Gtk::HeaderBar* header, Gtk::Button* btnSave);
 
 	/**
+	 * Applies a writability state to every toplevel window.
+	 * Widgets marked with cssClass are locked or restored; those also marked
+	 * CSS_RO_VIEW flip icon and tooltip between edit and view instead, staying
+	 * sensitive. Unmarked widgets are untouched.
+	 * @param cssClass CSS_RO_LOCKED_CONFIG or CSS_RO_LOCKED_PROJECT.
+	 * @param writable false locks, true restores.
+	 */
+	static void applyWritability(const string& cssClass, bool writable) noexcept;
+
+	/**
+	 * Applies both writability states to a single widget tree.
+	 * Used when widgets become visible after the toplevel sweep ran.
+	 * @param widget          Root of the tree to process.
+	 * @param configWritable  State for CSS_RO_LOCKED_CONFIG markers.
+	 * @param projectWritable State for CSS_RO_LOCKED_PROJECT markers.
+	 */
+	static void applyWritability(Gtk::Widget* widget, bool configWritable, bool projectWritable) noexcept;
+
+	/**
 	 * Registers an Editable widget, so when it change the dirty flag is raised
 	 * @param widget
 	 */
@@ -802,8 +827,9 @@ public:
 	/**
 	 * Sets the subtitle in the header bar.
 	 * @param text The text to display, or empty to clear.
+	 * @param tooltip Header tooltip explaining subtitle markers, or empty to clear.
 	 */
-	static void setSubtitle(const string& text);
+	static void setSubtitle(const string& text, const string& tooltip = "");
 
 	/**
 	 * Add tabulation.
@@ -999,6 +1025,15 @@ public:
 	static void attachNameFilter(Gtk::Entry* entry, size_t maxLen = 128) noexcept;
 
 protected:
+
+	/**
+	 * Recursively applies one writability marker to a widget tree.
+	 * Marked widgets do not nest.
+	 * @param widget   Root of the tree to process.
+	 * @param cssClass Marker selecting the widgets to act on.
+	 * @param writable false locks, true restores.
+	 */
+	static void sweepWritability(Gtk::Widget* widget, const string& cssClass, bool writable) noexcept;
 
 	/// Keeps track of the number of tabulations for XML files.
 	inline static string tabs;

--- a/src/Ui/DataDialogs/DialogDevice.hpp
+++ b/src/Ui/DataDialogs/DialogDevice.hpp
@@ -72,6 +72,8 @@ protected:
 
 	void createSubItems(DataMap& values) noexcept override;
 	const string& getType()          const noexcept override { return TYPE_DEVICE; }
+
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
 	Storage::Data* createData(Values& rawData) const noexcept override;
 
 	void onEmpty()    noexcept override;

--- a/src/Ui/DataDialogs/DialogElement.hpp
+++ b/src/Ui/DataDialogs/DialogElement.hpp
@@ -133,6 +133,8 @@ protected:
 
 	const string& getType() const noexcept override { return TYPE_ELEMENT; }
 
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
+
 	Storage::Data* createData(Values& rawData) const noexcept override;
 
 	void addButtons(Storage::BoxButton& boxButton) noexcept override;

--- a/src/Ui/DataDialogs/DialogForm.cpp
+++ b/src/Ui/DataDialogs/DialogForm.cpp
@@ -129,7 +129,8 @@ void DialogForm::wireChildrenDialogs() noexcept {
 	if (not parent) return;
 	for (auto& [family, items] : parent->getChildren()) {
 		auto child{familyToDialog.at(family)};
-		child->action = action;
+		child->action   = action;
+		child->readOnly = readOnly;
 		child->setOwner(&items, currentData);
 	}
 
@@ -173,13 +174,14 @@ void DialogForm::createDeleteButton(BoxButton& boxButton, bool askConfirmation) 
 	boxButton.packButtonStart(*button);
 	button->set_image_from_icon_name(ICON_TRASH, Gtk::ICON_SIZE_BUTTON);
 	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_DELETE);
+	button->get_style_context()->add_class(getLockClass());
 	button->set_tooltip_text("Delete " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&, askConfirmation]() {
 		if (askConfirmation) {
 			if (Message::ask(
-					"Are you sure you want to remove " +
-					boxButton.getData()->createPrettyName() + "?", this
-				) != Gtk::ResponseType::RESPONSE_YES) return;
+				"Are you sure you want to remove " +
+				boxButton.getData()->createPrettyName() + "?", this
+			) != Gtk::ResponseType::RESPONSE_YES) return;
 		}
 		onDelClicked(boxButton);
 	});
@@ -190,6 +192,8 @@ void DialogForm::createEditButton(BoxButton& boxButton) noexcept {
 	boxButton.packButtonStart(*button);
 	button->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
 	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_EDIT);
+	button->get_style_context()->add_class(getLockClass());
+	button->get_style_context()->add_class(CSS_RO_VIEW);
 	button->set_tooltip_text("Edit " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&]() {
 		onEditClicked(boxButton);
@@ -201,6 +205,7 @@ void DialogForm::createCloneButton(BoxButton& boxButton) noexcept {
 	boxButton.packButtonStart(*button);
 	button->set_image_from_icon_name(ICON_COPY, Gtk::ICON_SIZE_BUTTON);
 	button->get_style_context()->add_class(CSS_BOX_BACKGROUND_COPY);
+	button->get_style_context()->add_class(getLockClass());
 	button->set_tooltip_text("Clone " + boxButton.getData()->createPrettyName());
 	button->signal_clicked().connect([&]() {
 		onCloneClicked(boxButton);
@@ -220,6 +225,8 @@ void DialogForm::onAddClicked() noexcept {
 	clearForm();
 	set_title("Add New " + Defaults::titleCase(getType()));
 	btnApply->set_label("Create");
+	// A prior view session may have hidden it; Add only fires on writable sources.
+	btnApply->set_visible(true);
 
 	// Ask form to create an empty Data, and connect any children dialogs.
 	currentData = createData();
@@ -259,8 +266,11 @@ void DialogForm::onEditClicked(BoxButton& boxButton) noexcept {
 	action = Actions::EDIT;
 	clearForm();
 	currentData = boxButton.getData();
-	set_title("Edit " + Defaults::titleCase(getType()) + " " + currentData->createPrettyName());
+	set_title(
+		(readOnly ? "View " : "Edit ") + Defaults::titleCase(getType()) + " " + currentData->createPrettyName()
+	);
 	btnApply->set_label("Save");
+	btnApply->set_visible(not readOnly);
 
 	// Connect any children dialogs.
 	wireChildrenDialogs();

--- a/src/Ui/DataDialogs/DialogForm.hpp
+++ b/src/Ui/DataDialogs/DialogForm.hpp
@@ -80,6 +80,13 @@ public:
 	void setBox(SortableFlowBox* displayBox) noexcept { box = displayBox; }
 
 	/**
+	 * Flags this dialog's data source as read-only: edit opens in view mode.
+	 * Propagated to child dialogs when they are wired.
+	 * @param value
+	 */
+	void setReadOnly(bool value) noexcept { readOnly = value; }
+
+	/**
 	 * Clear the From leaving it empty for data entry.
 	 */
 	virtual void clearForm() noexcept abstract;
@@ -148,6 +155,16 @@ protected:
 
 	/// form action mode.
 	Actions action = Actions::ADD;
+
+	/// True when the data source cannot be written: edit becomes view.
+	bool readOnly = false;
+
+	/**
+	 * Writability marker for the item buttons this dialog creates
+	 * override it for different classes.
+	 * @return the marker CSS class.
+	 */
+	virtual const char* getLockClass() const noexcept { return CSS_RO_LOCKED_PROJECT; }
 
 	/// Maps family constants to their child DialogForm.
 	static std::unordered_map<string, DialogForm*> familyToDialog;

--- a/src/Ui/DataDialogs/DialogGroup.cpp
+++ b/src/Ui/DataDialogs/DialogGroup.cpp
@@ -35,7 +35,10 @@ DialogGroup::DialogGroup(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>& 
 		emptyString,
 		{},
 		CollectionHandler::getInstance(COLLECTION_ELEMENTS),
-		{}
+		{},
+		1,
+		// Group links are root config data.
+		CSS_RO_LOCKED_CONFIG
 	}
 {
 	Gtk::Button

--- a/src/Ui/DataDialogs/DialogGroup.hpp
+++ b/src/Ui/DataDialogs/DialogGroup.hpp
@@ -76,6 +76,8 @@ protected:
 
 	void createSubItems(DataMap& values) noexcept override;
 	const string& getType()          const noexcept override { return TYPE_GROUP; }
+
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
 	Storage::Data* createData(Values& rawData) const noexcept override;
 
 	void wireChildrenDialogs()       noexcept override;

--- a/src/Ui/DataDialogs/DialogInputSource.cpp
+++ b/src/Ui/DataDialogs/DialogInputSource.cpp
@@ -241,8 +241,9 @@ LEDSpicerUI::StringMap DialogInputSource::scanEventDevices() noexcept{
 
 	StringMap devices;
 
+	// Without a daemon binary this machine is not a target; its devices are misleading.
 	if (
-		Settings::get().isPortable() or
+		not Settings::get().hasBinary() or
 		not Defaults::isDevInputListener(comboBoxInputSelectInput->get_active_id())
 	) {
 		return devices;

--- a/src/Ui/DataDialogs/DialogInputSource.hpp
+++ b/src/Ui/DataDialogs/DialogInputSource.hpp
@@ -31,8 +31,8 @@ namespace LEDSpicerUI::Ui::DataDialogs {
 /**
  * LEDSpicerUI::Ui::DataDialogs::DialogInputSource
  * Dialog to add/edit event sources (hardware input devices) for multi-source inputs.
- * When running locally, scans /dev/input/ for event devices and populates a combo.
- * Selecting "Other" or running in portable mode falls back to a manual text entry.
+ * With a daemon binary present, scans /dev/input/ for event devices and populates a combo.
+ * Selecting "Other" or lacking the binary falls back to a manual text entry.
  * Both the combo and entry resolve to a single source value via resolvedSource().
  */
 class DialogInputSource : public DialogFormHost, public SingletonDialog<DialogInputSource> {

--- a/src/Ui/DataDialogs/DialogProcess.hpp
+++ b/src/Ui/DataDialogs/DialogProcess.hpp
@@ -58,6 +58,8 @@ protected:
 
 	const string& getType() const noexcept override { return TYPE_MAP; }
 
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
+
 	Storage::Data* createData(Values& rawData) const noexcept override;
 };
 

--- a/src/Ui/DataDialogs/DialogRestrictor.cpp
+++ b/src/Ui/DataDialogs/DialogRestrictor.cpp
@@ -349,8 +349,8 @@ void DialogRestrictor::updateWaysTestState() noexcept {
 	flowboxWays->unselect_all();
 	flowboxWays->set_selection_mode(live ? Gtk::SELECTION_SINGLE : Gtk::SELECTION_NONE);
 	flowboxWays->set_activate_on_single_click(live);
-	// Portable: informational. Otherwise sensitive only when live.
-	flowboxWays->set_sensitive(live or Config::Settings::get().isPortable());
+	// No daemon: informational. Otherwise sensitive only when live.
+	flowboxWays->set_sensitive(live or not Config::Settings::get().hasBinary());
 
 	// Narrowing: multi-interface restrictor with 2+ mappings, while live.
 	const string name {selectorCombo->get_active_id()};

--- a/src/Ui/DataDialogs/DialogRestrictor.hpp
+++ b/src/Ui/DataDialogs/DialogRestrictor.hpp
@@ -120,6 +120,8 @@ protected:
 
 	void createSubItems(DataMap& values)               noexcept override;
 	const string& getType()                        const noexcept override { return TYPE_RESTRICTOR; }
+
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
 	Storage::Data* createData(Values& rawData) const noexcept override;
 
 	void onEmpty()    noexcept override;

--- a/src/Ui/DataDialogs/DialogRestrictorMap.hpp
+++ b/src/Ui/DataDialogs/DialogRestrictorMap.hpp
@@ -86,6 +86,8 @@ protected:
 	bool checkAvailableInterfaces() const noexcept;
 
 	const string& getType() const noexcept override { return TYPE_RESTRICTOR_MAP; }
+
+	const char* getLockClass() const noexcept override { return CSS_RO_LOCKED_CONFIG; }
 	Storage::Data* createData(Values& rawData) const noexcept override;
 
 	void afterCreate(Storage::BoxButton& boxButton) noexcept override;

--- a/src/Ui/DataDialogs/DialogSelect.cpp
+++ b/src/Ui/DataDialogs/DialogSelect.cpp
@@ -105,8 +105,18 @@ void DialogSelect::open() noexcept {
 
 void DialogSelect::refresh() noexcept {
 	request->displayBox->wipe();
-	for (auto btn : *destination)
+	/*
+	 * Link rows live detached in their owner's collection and bypass BoxButtonCollection::populateBox,
+	 * so this display moment must apply the writability state itself.
+	 */
+	const auto& settings {Config::Settings::get()};
+	const bool
+		configWritable  {settings.isRootConfigWritable()},
+		projectWritable {settings.isProjectDirWritable()};
+	for (auto btn : *destination) {
+		Defaults::applyWritability(btn, configWritable, projectWritable);
 		request->displayBox->add(*btn);
+	}
 	request->displayBox->show_all();
 }
 
@@ -220,6 +230,8 @@ void DialogSelect::addDisplayButtons(Storage::BoxButton& boxButton) noexcept {
 		boxButton.packButtonStart(*btn);
 		btn->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
 		btn->get_style_context()->add_class(CSS_BOX_BACKGROUND_EDIT);
+		btn->get_style_context()->add_class(request->lockClass);
+		btn->get_style_context()->add_class(CSS_RO_VIEW);
 		btn->set_tooltip_text("Edit");
 		btn->signal_clicked().connect([&boxButton, this]() {
 			DialogLinkEditor::getInstance()->open(
@@ -234,6 +246,7 @@ void DialogSelect::addDisplayButtons(Storage::BoxButton& boxButton) noexcept {
 	boxButton.packButtonStart(*btn);
 	btn->set_image_from_icon_name(ICON_DELETE, Gtk::ICON_SIZE_BUTTON);
 	btn->get_style_context()->add_class(CSS_BOX_BACKGROUND_DELETE);
+	btn->get_style_context()->add_class(request->lockClass);
 	btn->set_tooltip_text("Remove");
 	btn->signal_clicked().connect([&boxButton, this]() {
 		Defaults::markDirty();

--- a/src/Ui/DataDialogs/DialogSelect.hpp
+++ b/src/Ui/DataDialogs/DialogSelect.hpp
@@ -23,6 +23,7 @@
 #include "DialogLinkEditor.hpp"
 #include "Storage/CollectionHandler.hpp"
 #include "Storage/Selection.hpp"
+#include "config/Settings.hpp"
 
 #pragma once
 
@@ -75,6 +76,9 @@ public:
 
 		/// Minimum number of items that must be selected to enable the Apply button.
 		const int minSelection = 1;
+
+		/// Writability marker for the per-link buttons.
+		const char* lockClass = CSS_RO_LOCKED_PROJECT;
 
 	};
 

--- a/src/Ui/DialogProject.cpp
+++ b/src/Ui/DialogProject.cpp
@@ -30,12 +30,21 @@ DialogProject::DialogProject(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> con
 {
 
 	// Get widgets
-	builder->get_widget("LabelProjectsPath",     labelProjectsPath);
-	builder->get_widget("FileProjectsDirSelect", fileProjectsDirSelect);
-	builder->get_widget("ComboSelectProject",    comboSelectProject);
-	builder->get_widget("InputNewProjectName",   inputNewProjectName);
-	builder->get_widget("BoxProjectActions",     boxProjectActions);
-	builder->get_widget("BoxNewProjectName",     boxNewProjectName);
+	builder->get_widget("LabelProjectsPath",        labelProjectsPath);
+	builder->get_widget("FileProjectsDirSelect",    fileProjectsDirSelect);
+	builder->get_widget("ComboSelectProject",       comboSelectProject);
+	builder->get_widget("InputNewProjectName",      inputNewProjectName);
+	builder->get_widget("ToggleNewProjectPortable", toggleNewProjectPortable);
+	builder->get_widget("BoxProjectActions",        boxProjectActions);
+	builder->get_widget("BoxNewProjectName",        boxNewProjectName);
+	builder->get_widget("BoxProjectConvert",        boxProjectConvert);
+	builder->get_widget("BtnProjectMakePortable",   btnProjectMakePortable);
+	builder->get_widget("BtnProjectDeploy",         btnProjectDeploy);
+	builder->get_widget("BtnProjectUseSystem",      btnProjectUseSystem);
+
+	btnProjectMakePortable->signal_clicked().connect([this]() { makePortable();     });
+	btnProjectDeploy->signal_clicked().connect([this]()       { deployToSystem();   });
+	btnProjectUseSystem->signal_clicked().connect([this]()    { useSystemConfig();  });
 
 	add_button("_Cancel", Gtk::ResponseType::RESPONSE_CANCEL);
 	btnApply = add_button("_Apply", Gtk::ResponseType::RESPONSE_APPLY);
@@ -54,9 +63,11 @@ DialogProject::DialogProject(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> con
 		}
 		else {
 			boxNewProjectName->set_visible(false);
+			toggleNewProjectPortable->set_active(false);
 			projectName = name;
 		}
 		refreshApplyState();
+		updateConvertActions();
 	});
 
 	Defaults::attachFilenameFilter(inputNewProjectName);
@@ -71,8 +82,22 @@ DialogProject::DialogProject(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> con
 		comboSelectProject->set_active_id(projectName);
 		inputNewProjectName->set_text("");
 		if (not pd.empty()) fileProjectsDirSelect->set_filename(pd);
+		/*
+		 * Unsaved project changes freeze the projects directory:
+		 * changing it would rebase the open project onto a different location.
+		 * Dirtiness cannot change while this modal dialog is open,
+		 * so evaluating here is enough.
+		 */
+		const bool pathsFrozen {not Settings::get().getCurrentProject().empty() and Defaults::isDirty()};
+		fileProjectsDirSelect->set_sensitive(not pathsFrozen);
+		fileProjectsDirSelect->get_parent()->set_tooltip_text(
+			pathsFrozen ? "Save or discard the project changes to change the projects folder." : ""
+		);
 		labelProjectsPath->set_text(pd.empty() ? "N/A" : pd);
 		boxNewProjectName->set_visible(projectName.empty());
+		// The portable choice only exists when the system config is an option too.
+		toggleNewProjectPortable->set_active(false);
+		toggleNewProjectPortable->set_visible(Settings::get().isSystemConfigAvailable());
 		btnApply->set_sensitive(false);
 		if (not pd.empty()) {
 			scanProjects();
@@ -101,6 +126,7 @@ void DialogProject::scanProjects() {
 	}
 	catch (const Glib::Error& e) {
 		Message::displayError(e.what(), this);
+		return;
 	}
 
 	// Transient: collected only to sort before populating the combo, which is the
@@ -142,6 +168,122 @@ void DialogProject::setProjectsDir(const string& projectsDir, bool setFileProjec
 void DialogProject::updateBoxProjectActions() {
 	refreshApplyState();
 	boxProjectActions->show_all();
+	updateConvertActions();
+}
+
+void DialogProject::updateConvertActions() {
+
+	const auto& s {Settings::get()};
+	const string id {comboSelectProject->get_active_id()};
+	const string projectDir {s.getProjectDir(id)};
+
+	// Conversions act on existing projects only.
+	if (id.empty() or not Glib::file_test(projectDir, Glib::FILE_TEST_IS_DIR)) {
+		boxProjectConvert->set_visible(false);
+		return;
+	}
+	boxProjectConvert->set_visible(true);
+
+	const string& systemConf {s.getConfigPath()};
+	const bool
+		isPortable         {Glib::file_test(projectDir + CONFIG_FILE, Glib::FILE_TEST_EXISTS)},
+		systemConfExists   {not systemConf.empty() and Glib::file_test(systemConf, Glib::FILE_TEST_EXISTS)},
+		projectDirWritable {Settings::isPathWritable(projectDir)},
+		// The open project cannot be converted with unsaved changes.
+		frozen             {id == s.getCurrentProject() and Defaults::isDirty()};
+
+	btnProjectMakePortable->set_visible(not isPortable);
+	btnProjectDeploy->set_visible(isPortable);
+	btnProjectUseSystem->set_visible(isPortable);
+
+	btnProjectMakePortable->set_sensitive(not frozen and systemConfExists and projectDirWritable);
+	btnProjectDeploy->set_sensitive(not frozen and Settings::isPathWritable(systemConf));
+	btnProjectUseSystem->set_sensitive(not frozen and systemConfExists and projectDirWritable);
+
+	// Insensitive buttons show no tooltip; the reason goes on the row.
+	string reason;
+	if (frozen)
+		reason = "Save or discard the project changes first.";
+	else if (not isPortable and not systemConfExists)
+		reason = "There is no system configuration to copy.";
+	else if (isPortable and not systemConfExists and not Settings::isPathWritable(systemConf))
+		reason = "There is no system configuration location.";
+	else if (not projectDirWritable)
+		reason = "The project directory is read-only.";
+	boxProjectConvert->set_tooltip_text(reason);
+}
+
+void DialogProject::makePortable() {
+
+	const string id {comboSelectProject->get_active_id()};
+	if (Message::ask(
+		"Copy the system configuration into \"" + id + "\"?\n"
+		"The project will use its own copy from then on.",
+		this
+	) != Gtk::ResponseType::RESPONSE_YES) return;
+
+	try {
+		std::filesystem::copy_file(
+			Settings::get().getConfigPath(),
+			Settings::get().getProjectDir(id) + CONFIG_FILE
+		);
+		afterConversion("Project \"" + id + "\" is now portable", true);
+	}
+	catch (const std::filesystem::filesystem_error& e) {
+		Message::displayError("Unable to make the project portable: " + string(e.what()), this);
+	}
+}
+
+void DialogProject::deployToSystem() {
+
+	const string id {comboSelectProject->get_active_id()};
+	const string& systemConf {Settings::get().getConfigPath()};
+	if (Message::ask(
+		"Overwrite the system configuration with the one from \"" + id + "\"?\n"
+		"The previous one is kept as " CONFIG_FILE + BACKUP_SUFFIX + ".",
+		this
+	) != Gtk::ResponseType::RESPONSE_YES) return;
+
+	try {
+		if (Glib::file_test(systemConf, Glib::FILE_TEST_EXISTS))
+			std::filesystem::copy_file(systemConf, systemConf + BACKUP_SUFFIX, std::filesystem::copy_options::overwrite_existing);
+		std::filesystem::copy_file(
+			Settings::get().getProjectDir(id) + CONFIG_FILE,
+			systemConf,
+			std::filesystem::copy_options::overwrite_existing
+		);
+		// The project keeps its embedded config; nothing to reload.
+		afterConversion("Deployed \"" + id + "\" to the system configuration", false);
+	}
+	catch (const std::filesystem::filesystem_error& e) {
+		Message::displayError("Unable to deploy to the system configuration: " + string(e.what()), this);
+	}
+}
+
+void DialogProject::useSystemConfig() {
+
+	const string id {comboSelectProject->get_active_id()};
+	if (Message::ask(
+		"Stop using the own configuration of \"" + id + "\" and follow the system one?\n"
+		"The project copy is kept as " CONFIG_FILE + BACKUP_SUFFIX + ".",
+		this
+	) != Gtk::ResponseType::RESPONSE_YES) return;
+
+	const string embedded {Settings::get().getProjectDir(id) + CONFIG_FILE};
+	try {
+		std::filesystem::rename(embedded, embedded + BACKUP_SUFFIX);
+		afterConversion("Project \"" + id + "\" now follows the system configuration", true);
+	}
+	catch (const std::filesystem::filesystem_error& e) {
+		Message::displayError("Unable to switch to the system configuration: " + string(e.what()), this);
+	}
+}
+
+void DialogProject::afterConversion(const string& message, bool sourceChanged) {
+	if (sourceChanged and comboSelectProject->get_active_id() == Settings::get().getCurrentProject())
+		currentProjectConverted = true;
+	StatusBar::getInstance().push(message, StatusBar::Severity::Success);
+	updateConvertActions();
 }
 
 void DialogProject::checkNewName(const string& name) const {

--- a/src/Ui/DialogProject.hpp
+++ b/src/Ui/DialogProject.hpp
@@ -40,6 +40,24 @@ public:
 
 	const string& getProjectName() const;
 
+	/**
+	 * Whether a new project should embed its config despite an available system one.
+	 * @return true when portable was requested.
+	 */
+	bool isPortableRequested() const noexcept {
+		return toggleNewProjectPortable->get_active();
+	}
+
+	/**
+	 * keeps a single use flag.
+	 * @return true once per such conversion.
+	 */
+	bool takeCurrentProjectConverted() noexcept {
+		const bool value {currentProjectConverted};
+		currentProjectConverted = false;
+		return value;
+	}
+
 	void setProjectsDir(const string& projectsDir, bool setFileProjectsDirSelector);
 
 	/**
@@ -59,11 +77,22 @@ protected:
 
 	Gtk::Entry* inputNewProjectName = nullptr;
 
+	Gtk::ToggleButton* toggleNewProjectPortable = nullptr;
+
 	Gtk::Button* btnApply = nullptr;
 
 	Gtk::Box
 		* boxNewProjectName = nullptr, // Label + Entry pair.
-		* boxProjectActions = nullptr; // Open / Select project actions.
+		* boxProjectActions = nullptr, // Open / Select project actions.
+		* boxProjectConvert = nullptr; // Config location conversions for the selected project.
+
+	Gtk::Button
+		* btnProjectMakePortable = nullptr,
+		* btnProjectDeploy       = nullptr,
+		* btnProjectUseSystem    = nullptr;
+
+	/// True when a conversion changed the open project's config location; see takeCurrentProjectConverted().
+	bool currentProjectConverted = false;
 
 	Gtk::ComboBoxText* comboSelectProject = nullptr;
 
@@ -86,6 +115,37 @@ protected:
 	 * Sets Apply sensitivity and the name-entry error icon for the current selection.
 	 */
 	void refreshApplyState();
+
+	/**
+	 * Shows the conversion actions matching the selected project's on-disk
+	 * config location, disabled with the reason when not executable.
+	 */
+	void updateConvertActions();
+
+	/**
+	 * Copies the system config into the selected project's directory.
+	 */
+	void makePortable();
+
+	/**
+	 * Copies the selected project's embedded config over the system one,
+	 * keeping the previous system config as a backup.
+	 */
+	void deployToSystem();
+
+	/**
+	 * Renames the selected project's embedded config to a backup so the
+	 * project follows the system config again.
+	 */
+	void useSystemConfig();
+
+	/**
+	 * Reports a finished conversion and refreshes the actions.
+	 * @param message status bar text.
+	 * @param sourceChanged true when the project's config location moved,
+	 *        requiring a reload if it is the open project.
+	 */
+	void afterConversion(const string& message, bool sourceChanged);
 
 };
 

--- a/src/Ui/DialogSettings.cpp
+++ b/src/Ui/DialogSettings.cpp
@@ -74,9 +74,9 @@ bool DialogSettings::startup(Gtk::Window* parent) {
 		"ledspicerd was not found in your system.\n\n"
 		"You can:\n"
 		"• Locate the binary manually if LEDSpicer is installed\n"
-		"• Continue in portable mode (requires data directory)\n\n"
-		"Note: In portable mode, ledspicer.conf is stored\n"
-		"within the project directory."
+		"• Continue without it (requires data directory)\n\n"
+		"Note: Without the daemon binary, ledspicer.conf is\n"
+		"stored within each project directory."
 		:
 		"LEDSpicer was found but the data directory is missing or invalid.\n\n"
 		"Please configure the data directory to continue.\n"
@@ -177,6 +177,17 @@ DialogSettings::DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Buil
 		const auto& s = Settings::get();
 		if (not s.getBinaryPath().empty())
 			fileBinary->set_filename(s.getBinaryPath());
+		/*
+		 * Unsaved project changes freeze the binary: changing it retargets the
+		 * config and projects paths and forces a reload. Dirtiness cannot change
+		 * while this modal dialog is open, so evaluating here is enough.
+		 */
+		const bool pathsFrozen {not s.getCurrentProject().empty() and Defaults::isDirty()};
+		fileBinary->set_sensitive(not pathsFrozen);
+		// Insensitive widgets get no tooltip; explain on the enclosing row.
+		fileBinary->get_parent()->set_tooltip_text(
+			pathsFrozen ? "Save or discard the project changes to change the binary." : ""
+		);
 		if (not s.getDataDir().empty())
 			fileDataDirSelect->set_filename(s.getDataDir());
 		switchInteractiveMode->set_active(s.isInteractiveMode());
@@ -357,11 +368,23 @@ bool DialogSettings::detectLedspicerVersion() {
 }
 
 void DialogSettings::setBinaryPath(const string& binaryPath, bool setFileBinarySelector) {
-	Settings::get().setBinaryPath(binaryPath);
+
+	auto& settings {Settings::get()};
+
+	const string
+		oldConfigPath {settings.getActiveConfigPath()},
+		oldProjectDir {settings.getProjectDir()};
+
+	settings.setBinaryPath(binaryPath);
 	if (detectLedspicerVersion()) {
 		processBinary();
 		if (setFileBinarySelector) fileBinary->set_filename(binaryPath);
 	}
+
+	// The open project must be reloaded from the new locations on close.
+	if (not settings.getCurrentProject().empty() and (
+		oldConfigPath != settings.getActiveConfigPath() or oldProjectDir != settings.getProjectDir()
+	)) needProjectReload = true;
 }
 
 void DialogSettings::updateBinaryStatusLabel(const string& version) {
@@ -378,7 +401,6 @@ void DialogSettings::updateBinaryStatusLabel(const string& version) {
 		labelBinaryPath->set_text(Settings::get().getBinaryPath());
 	}
 	switchInteractiveMode->set_sensitive(detected);
-	// Mode is derived automatically by Settings from binaryPath state.
 }
 
 void DialogSettings::processBinary() {
@@ -425,25 +447,13 @@ void DialogSettings::processBinary() {
 
 void DialogSettings::setConfigPath(const string& configPath) {
 
+	Settings::get().setConfigPath(configPath);
 	if (configPath.empty()) {
-		Settings::get().setConfigPath("");
 		labelConfigPath->set_text("N/A");
 		return;
 	}
-
-	bool isWritable = false;
-	try {
-		auto file = Gio::File::create_for_path(configPath);
-		auto info = file->query_info("access::can-write");
-		isWritable = info->get_attribute_boolean("access::can-write");
-	}
-	catch (...) {
-		Settings::get().setConfigPath("");
-		return;
-	}
-
-	Settings::get().setConfigPath(configPath);
-	labelConfigPath->set_text((isWritable ? "" : "🔒") + configPath);
+	// The label describes this exact path; the active source may differ.
+	labelConfigPath->set_text((Settings::isPathWritable(configPath) ? "" : "🔒") + configPath);
 }
 
 void DialogSettings::setDataDir(const string& dataDir, bool setFileDataDirSelector) {

--- a/src/Ui/DialogSettings.hpp
+++ b/src/Ui/DialogSettings.hpp
@@ -77,6 +77,17 @@ public:
 	void onClose(std::function<void()> cb) noexcept { onClosed = std::move(cb); }
 
 	/**
+	 * Consumes the flag set when a binary change retargeted the open project's
+	 * paths; the caller must then reload it.
+	 * @return true once per such change.
+	 */
+	bool takeProjectReload() noexcept {
+		const bool value {needProjectReload};
+		needProjectReload = false;
+		return value;
+	}
+
+	/**
 	 * Sets the binary path, runs detection, and updates UI.
 	 * @param binaryPath
 	 * @param setFileBinarySelector if true, syncs the file chooser widget.
@@ -133,7 +144,9 @@ protected:
 		/// Guards against recursive signal firing when syncing theme selection.
 		selectingTheme  = false,
 		/// True while signal_show() is mirroring Settings into widgets; suppresses auto-save.
-		syncing         = false;
+		syncing         = false,
+		/// True when a binary change retargeted the open project's paths; see takeProjectReload().
+		needProjectReload = false;
 
 	DialogSettings(BaseObjectType* obj, const Glib::RefPtr<Gtk::Builder>& builder);
 

--- a/src/Ui/DirectoryNavigator.cpp
+++ b/src/Ui/DirectoryNavigator.cpp
@@ -173,6 +173,7 @@ void DirectoryNavigator::wireDirButtons(Storage::BoxButton& bb) noexcept {
 	bb.packButtonStart(*editBtn);
 	editBtn->set_image_from_icon_name(ICON_EDIT, Gtk::ICON_SIZE_BUTTON);
 	editBtn->get_style_context()->add_class(CSS_BOX_BACKGROUND_EDIT);
+	editBtn->get_style_context()->add_class(CSS_RO_LOCKED_PROJECT);
 	editBtn->set_tooltip_text("Rename " + de->createPrettyName());
 	editBtn->signal_clicked().connect([this, de, &bb]() {
 
@@ -194,6 +195,7 @@ void DirectoryNavigator::wireDirButtons(Storage::BoxButton& bb) noexcept {
 	bb.packButtonStart(*delBtn);
 	delBtn->set_image_from_icon_name(ICON_TRASH, Gtk::ICON_SIZE_BUTTON);
 	delBtn->get_style_context()->add_class(CSS_BOX_BACKGROUND_DELETE);
+	delBtn->get_style_context()->add_class(CSS_RO_LOCKED_PROJECT);
 	delBtn->set_tooltip_text("Delete " + de->createPrettyName());
 	delBtn->signal_clicked().connect([this, de, &bb]() {
 		if (Message::ask(

--- a/src/Ui/Layout/LayoutElement.cpp
+++ b/src/Ui/Layout/LayoutElement.cpp
@@ -325,6 +325,8 @@ void LayoutElement::persistPosition() noexcept {
 bool LayoutElement::onButtonPress(GdkEventButton* ev) noexcept {
 	if (ev->button != 1) return false;
 	if (active) return true;
+	// Read-only root config: position writes are suppressed, so never start a drag.
+	if (not Config::Settings::get().isRootConfigWritable()) return true;
 	dragging    = true;
 	dragMoved   = false;
 	dragOffsetX = ev->x;

--- a/src/Ui/MainWindow.cpp
+++ b/src/Ui/MainWindow.cpp
@@ -103,10 +103,18 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 	builder->get_widget("DaemonBusyWindow", busyWindow);
 	builder->get_widget("DaemonBusyLabel",  busyLabel);
 
-	// Settings has no Apply: re-evaluate the sandbox and daemon controls on close.
+	// Refresh on close because settings has no Apply.
 	DialogSettings::getInstance()->onClose([this]() {
 		syncSandbox();
 		updateDaemonControls();
+		/*
+		 * A daemon change retargeted the paths: reload the project from the new
+		 * locations (which re-derives writability); otherwise just re-apply it.
+		 */
+		if (DialogSettings::getInstance()->takeProjectReload())
+			openProject(Settings::get().getCurrentProject());
+		else
+			applyWritability();
 	});
 
 	// Config changes stale the staged config; restrictors are included for the rotator test.
@@ -140,20 +148,25 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 	// Save project
 	btnSaveProject->signal_clicked().connect([this]() {
 		try {
-			// Saving under the wrong mode would write the config to the other mode's
-			// location and duplicate it; block until the mode matches the project.
-			if (not projectMatchesMode(Settings::get().getCurrentProject())) {
-				const auto [appMode, projectMode] {Settings::getModeLabels(Settings::get().getMode())};
-				throw Message(
-					"This project was created for " + projectMode + " mode, but the application is running in "
-					+ appMode + " mode.\nSwitch back to " + projectMode + " mode to save it."
-				);
-			}
 			if (boxRandomColors->get_children().size() == 1) {
 				throw Message("The number of random colors need to be more than one or none.");
 			}
 
-			const bool backupKept {ProjectFile::saveProject([&]() {
+			const bool
+				rootWritable    {Settings::get().isRootConfigWritable()},
+				projectWritable {Settings::get().isProjectDirWritable()};
+
+			// RO project.
+			if (not rootWritable or not projectWritable) {
+				const string
+					skipped {rootWritable ? "project files are" : "root configuration is"},
+					saved   {rootWritable ? "root configuration" : "project files"};
+				if (Message::ask(
+					"The " + skipped + " read-only and will NOT be saved.\nSave the " + saved + "?", this
+				) != Gtk::ResponseType::RESPONSE_YES) return;
+			}
+
+			auto saveConfig {[&]() {
 				ConfigFile::save(ConfigFile::ConfigData(
 					Settings::get().getActiveConfigPath(),
 					Settings::get().getCurrentProject(),
@@ -165,15 +178,30 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 					groups,
 					processes
 				));
+			}};
 
-				inputNavigator.save();
-				animationNavigator.save();
-				profileNavigator.save();
-			})};
+			bool backupKept {false};
+			if (projectWritable) {
+				backupKept = ProjectFile::saveProject([&]() {
+					if (rootWritable) saveConfig();
+					inputNavigator.save();
+					animationNavigator.save();
+					profileNavigator.save();
+				});
+			}
+			else {
+				// A system-sourced config lives outside the project directory.
+				saveConfig();
+			}
 
 			Defaults::cleanDirty();
 			DialogSettings::getInstance()->saveSettings();
-			StatusBar::getInstance().push("Project saved", StatusBar::Severity::Success);
+			if (rootWritable and projectWritable)
+				StatusBar::getInstance().push("Project saved", StatusBar::Severity::Success);
+			else
+				StatusBar::getInstance().push(
+					"Project partially saved (read-only parts skipped)", StatusBar::Severity::Warning
+				);
 			if (backupKept)
 				StatusBar::getInstance().push("Backup saved", StatusBar::Severity::Success);
 		}
@@ -245,7 +273,7 @@ MainWindow::MainWindow(BaseObjectType* obj, Glib::RefPtr<Gtk::Builder> const &bu
 		const string& defaultProject = Settings::get().getDefaultProject();
 		if (not defaultProject.empty())
 			openProject(defaultProject);
-		// Settings (and thus the mode) are loaded now: build the test sandbox.
+		// Settings are loaded now: build the test sandbox.
 		syncSandbox();
 		updateDaemonControls();
 		Defaults::setIgnoreChanges(false);
@@ -335,31 +363,37 @@ void MainWindow::prepareDialogs(Glib::RefPtr<Gtk::Builder> const &builder) {
 	});
 
 	btnSelectProject->signal_clicked().connect([this]() {
-		if (DialogProject::getInstance()->run() != Gtk::ResponseType::RESPONSE_APPLY) {
-			DialogProject::getInstance()->hide();
+		auto dialog {DialogProject::getInstance()};
+		const auto response {dialog->run()};
+		dialog->hide();
+		/*
+		 * A conversion moved the open project's config on disk;
+		 * it must reload regardless of how the dialog was closed.
+		 * Conversions require a clean project, so the reload cannot lose work.
+		 */
+		const bool reloadCurrent {dialog->takeCurrentProjectConverted()};
+		if (response != Gtk::ResponseType::RESPONSE_APPLY) {
+			if (reloadCurrent) openProject(Settings::get().getCurrentProject());
 			return;
 		}
-		const string& newProject {DialogProject::getInstance()->getProjectName()};
+		const string& newProject {dialog->getProjectName()};
 		if (newProject == Settings::get().getCurrentProject()) {
+			if (reloadCurrent) {
+				openProject(newProject);
+				return;
+			}
 			if (not Defaults::isDirty()) {
-				Message::displayInfo("Already working on that project", DialogProject::getInstance());
-				DialogProject::getInstance()->hide();
+				Message::displayInfo("Already working on that project");
 				return;
 			}
-			if (Message::ask("Discard unsaved changes and reload \"" + newProject + "\" from disk?", DialogProject::getInstance()) != Gtk::ResponseType::RESPONSE_YES) {
-				DialogProject::getInstance()->hide();
+			if (Message::ask("Discard unsaved changes and reload \"" + newProject + "\" from disk?") != Gtk::ResponseType::RESPONSE_YES)
 				return;
-			}
 			openProject(newProject);
-			DialogProject::getInstance()->hide();
 			return;
 		}
-		if (Defaults::isDirty() and Message::ask("All unsaved changes will be loss, are you sure?", DialogProject::getInstance()) != Gtk::ResponseType::RESPONSE_YES) {
-			DialogProject::getInstance()->hide();
+		if (Defaults::isDirty() and Message::ask("All unsaved changes will be loss, are you sure?") != Gtk::ResponseType::RESPONSE_YES)
 			return;
-		}
-		openProject(newProject);
-		DialogProject::getInstance()->hide();
+		openProject(newProject, dialog->isPortableRequested());
 	});
 }
 
@@ -404,31 +438,25 @@ LEDSpicerUI::Values MainWindow::packLedspicerConfig() const noexcept {
 	return r;
 }
 
-bool MainWindow::projectMatchesMode(const string& name) const noexcept {
-	const string projectDir {Settings::get().getProjectsDir() + name + '/'};
-	// A new project (no directory yet) adopts the current mode on its first save.
-	if (not Glib::file_test(projectDir, Glib::FileTest::FILE_TEST_IS_DIR))
-		return true;
-	const bool portableProject {Glib::file_test(projectDir + CONFIG_FILE, Glib::FileTest::FILE_TEST_EXISTS)};
-	return portableProject == Settings::get().isPortable();
-}
+void MainWindow::openProject(const string& name, bool portable) {
 
-void MainWindow::openProject(const string& name) {
+	// Resolves the config source for the project (embedded config wins).
+	Settings::get().setCurrentProject(name);
+	if (portable)
+		Settings::get().setConfigSource(Settings::ConfigSource::Project);
 
-	// Opening a project under the wrong mode reads the wrong config location; refuse
-	// before touching state.
-	if (not projectMatchesMode(name)) {
-		const auto [appMode, projectMode] {Settings::getModeLabels(Settings::get().getMode())};
+	// A missing config is a new one; without a writable target it can never exist.
+	const string activeConfig {Settings::get().getActiveConfigPath()};
+	if (not Glib::file_test(activeConfig, Glib::FileTest::FILE_TEST_EXISTS)
+		and not Settings::get().isRootConfigWritable()) {
 		Message::displayError(
-			"Unable to open project \"" + name + "\" because it was created for " + projectMode + " mode.\n"
-			"The application is currently running in " + appMode + " mode. Please switch modes to open this project.",
+			"There is no configuration for \"" + name + "\" and no writable location to create one.",
 			this
 		);
+		Settings::get().setCurrentProject("");
 		return;
 	}
 
-	Settings::get().setCurrentProject(name);
-	Defaults::setSubtitle(name);
 	comboColors->set_active_id("");
 
 	Message::beginBatch();
@@ -481,8 +509,43 @@ void MainWindow::openProject(const string& name) {
 	toggleConnect->set_active(false);
 	ignoreConnectToggle = false;
 	updateDaemonControls();
+	applyWritability();
 
 	Message::finishBatch(loadFailed ? "Project could not be loaded" : "Project loaded");
+}
+
+void MainWindow::applyWritability() noexcept {
+
+	auto& settings {Settings::get()};
+	// Without a project the whole tab area is already disabled.
+	if (settings.getCurrentProject().empty()) return;
+
+	const bool
+		rootWritable    {settings.isRootConfigWritable()},
+		projectWritable {settings.isProjectDirWritable()};
+
+	Defaults::applyWritability(CSS_RO_LOCKED_CONFIG,  rootWritable);
+	Defaults::applyWritability(CSS_RO_LOCKED_PROJECT, projectWritable);
+
+	DialogDevice::getInstance()->setReadOnly(not rootWritable);
+	DialogRestrictor::getInstance()->setReadOnly(not rootWritable);
+	DialogProcess::getInstance()->setReadOnly(not rootWritable);
+	DialogGroup::getInstance()->setReadOnly(not rootWritable);
+	DialogInput::getInstance()->setReadOnly(not projectWritable);
+	DialogAnimation::getInstance()->setReadOnly(not projectWritable);
+	DialogProfile::getInstance()->setReadOnly(not projectWritable);
+
+	// The lock and its explanation live with the project name.
+	string lockTip;
+	if (not rootWritable)
+		lockTip = "The root configuration is read-only.";
+	if (not projectWritable)
+		lockTip += string{lockTip.empty() ? "" : "\n"} + "The project directory is read-only.";
+	Defaults::setSubtitle(
+		(lockTip.empty() ? "" : "🔒 ") + settings.getCurrentProject() +
+		(settings.getConfigSource() == Settings::ConfigSource::Project ? " · portable" : ""),
+		lockTip
+	);
 }
 
 void MainWindow::onConnectToggled() {
@@ -666,8 +729,8 @@ void MainWindow::updateDaemonControls() noexcept {
 		Settings::get().isInteractive()
 		and ((hasDevices and portOk) or hasRestrictors)
 	};
-	// Hidden on portable; visible otherwise, enabled only when a test can run.
-	toggleConnect->set_visible(not Settings::get().isPortable());
+	// Hidden without a daemon binary; visible otherwise, enabled only when a test can run.
+	toggleConnect->set_visible(Settings::get().hasBinary());
 	toggleConnect->set_sensitive(eligible);
 
 	// A live test session whose project drifted out of eligibility must drop.

--- a/src/Ui/MainWindow.hpp
+++ b/src/Ui/MainWindow.hpp
@@ -211,16 +211,17 @@ protected:
 	 * Opens a project by name: sets current project, loads its config, and activates the UI.
 	 * Persists the project to UI settings immediately if the config file already exists.
 	 * @param name project directory name
+	 * @param portable keep a new project's config inside its directory even
+	 *        when the system config is available.
 	 */
-	void openProject(const string& name);
+	void openProject(const string& name, bool portable = false);
 
 	/**
-	 * Whether a project's on-disk origin is compatible with the current mode.
-	 * A new project (no directory yet) adopts the current mode.
-	 * @param name project directory name
-	 * @return true if it may be opened or saved now.
+	 * Applies the writability of both config sources to the UI: locks the
+	 * affected tab pages and flags the data dialogs read-only. Runs after a
+	 * project is opened and whenever the settings dialog closes.
 	 */
-	bool projectMatchesMode(const string& name) const noexcept;
+	void applyWritability() noexcept;
 
 	/**
 	 * Reads a ledspicer.conf file.

--- a/src/Ui/ProfileDirectoryNavigator.cpp
+++ b/src/Ui/ProfileDirectoryNavigator.cpp
@@ -84,8 +84,8 @@ ProfileDirectoryNavigator::ProfileDirectoryNavigator(
 		if (selected.empty()) return;
 		auto bb {static_cast<Storage::BoxButton*>(selected.front())};
 		if (bb == defaultProfileBB) return;
-		// This is the only way we have to know if the selected is not a directory.
-		if (not dynamic_cast<Storage::Profile*>(bb->getData())) {
+
+		if (not dynamic_cast<Storage::Profile*>(bb->getData()) or not Settings::get().isProjectDirWritable()) {
 			if (defaultProfileBB and defaultProfileBB->get_parent() == box)
 				box->select_child(*defaultProfileBB);
 			else

--- a/src/Ui/Storage/BoxButtonCollection.cpp
+++ b/src/Ui/Storage/BoxButtonCollection.cpp
@@ -94,7 +94,16 @@ void BoxButtonCollection::swap(BoxButtonCollection& other) noexcept {
 }
 
 void BoxButtonCollection::populateBox(SortableFlowBox* box) noexcept {
+	/*
+	 * Items created while detached from any window miss the toplevel writability
+	 * sweep; becoming visible is the moment their state must be current.
+	 */
+	const auto& settings {Config::Settings::get()};
+	const bool
+		configWritable  {settings.isRootConfigWritable()},
+		projectWritable {settings.isProjectDirWritable()};
 	for (auto item : items) {
+		Defaults::applyWritability(item, configWritable, projectWritable);
 		box->add(*item);
 	}
 	box->show_all();

--- a/src/Ui/Storage/BoxButtonCollection.hpp
+++ b/src/Ui/Storage/BoxButtonCollection.hpp
@@ -23,6 +23,7 @@
 #include "SensitivityTracker.hpp"
 #include "SortableFlowBox.hpp"
 #include "BoxButton.hpp"
+#include "config/Settings.hpp"
 
 #pragma once
 

--- a/src/config/ConfigFile.hpp
+++ b/src/config/ConfigFile.hpp
@@ -21,7 +21,6 @@
  */
 
 #include "ProjectFile.hpp"
-#include "Storage/BoxButtonCollection.hpp"
 #include "Storage/Element.hpp"
 
 #pragma once

--- a/src/config/Settings.cpp
+++ b/src/config/Settings.cpp
@@ -20,10 +20,6 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <glibmm.h>
-#include <cmath>
-#include <iomanip>
-
 #include "Settings.hpp"
 
 using namespace LEDSpicerUI;
@@ -51,12 +47,10 @@ const StringUMap Settings::DEFAULTS = {
 void Settings::load(const Values& raw) noexcept {
 	for (const auto& [key, def] : DEFAULTS)
 		setValue(key, raw.getValue(key, def));
-	updateMode();
 }
 
 void Settings::setBinaryPath(const string& path) noexcept {
 	setValue(PATH_BINARY, path);
-	updateMode();
 }
 
 void Settings::setDataDir(const string& dir) noexcept {
@@ -83,7 +77,6 @@ void Settings::setDefaultProject(const string& name) noexcept {
 
 void Settings::setInteractiveMode(bool value) noexcept {
 	setValue(INTERACTIVE_MODE, value);
-	updateMode();
 }
 
 Settings::ThemeStyle Settings::getThemeStyle() const noexcept {
@@ -124,6 +117,7 @@ void Settings::setConfigPath(const string& path) noexcept {
 void Settings::setCurrentProject(const string& name) noexcept {
 	currentProject = name;
 	setValue(DEFAULT_PROJECT, name);
+	resolveConfigSource();
 }
 
 void Settings::setColorFiles(StringVector files) noexcept {
@@ -137,23 +131,55 @@ void Settings::setDataDirStatus(bool gameData, bool colors, bool controls) noexc
 	hasControls = controls;
 }
 
-string Settings::getProjectDir() const noexcept {
+string Settings::getProjectDir(const string& name) const noexcept {
 	const string& proj = getValue(PATH_PROJECT);
-	if (proj.empty() || currentProject.empty())
+	if (proj.empty() or name.empty())
 		return {};
-	return proj + currentProject + "/";
+	return proj + name + "/";
 }
 
 string Settings::getActiveConfigPath() const noexcept {
-	if (isPortable())
+	if (configSource == ConfigSource::Project)
 		return getProjectDir() + CONFIG_FILE;
 	return configPath;
 }
 
-void Settings::updateMode() noexcept {
-	if (getValue(PATH_BINARY).empty()) {
-		currentMode = Mode::Portable;
+void Settings::resolveConfigSource() noexcept {
+
+	if (currentProject.empty()) {
+		configSource = ConfigSource::System;
 		return;
 	}
-	currentMode = (getValue(INTERACTIVE_MODE) == HUMAN_TRUE) ? Mode::Interactive : Mode::Local;
+	// An embedded config makes the project portable.
+	if (Glib::file_test(getProjectDir() + CONFIG_FILE, Glib::FILE_TEST_EXISTS)) {
+		configSource = ConfigSource::Project;
+		return;
+	}
+	// No embedded config: use the system config when it exists or can be created there.
+	configSource = isSystemConfigAvailable() ? ConfigSource::System : ConfigSource::Project;
 }
+
+bool Settings::isSystemConfigAvailable() const noexcept {
+	return Glib::file_test(configPath, Glib::FILE_TEST_EXISTS) or isPathWritable(configPath);
+}
+
+bool Settings::isRootConfigWritable() const noexcept {
+	if (configSource == ConfigSource::Project)
+		return isProjectDirWritable();
+	return isPathWritable(configPath);
+}
+
+bool Settings::isProjectDirWritable() const noexcept {
+	return isPathWritable(getProjectDir());
+}
+
+bool Settings::isPathWritable(const string& path) noexcept {
+	if (path.empty())
+		return false;
+	string target {path};
+	// Missing target: probe the closest existing ancestor (can the target be created?).
+	while (not Glib::file_test(target, Glib::FILE_TEST_EXISTS))
+		target = Glib::path_get_dirname(target);
+	return access(target.c_str(), W_OK) == 0;
+}
+

--- a/src/config/Settings.hpp
+++ b/src/config/Settings.hpp
@@ -20,6 +20,10 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <glibmm.h>
+#include <cmath>
+#include <iomanip>
+
 #include "Values.hpp"
 
 #pragma once
@@ -59,11 +63,10 @@ public:
 		LAYOUT_GRID          {"layoutGrid"},
 		LAYOUT_TEST_TIMEOUT  {"layoutTestTimeout"};
 
-	/// Runtime mode — derived from binary detection result and interactiveMode preference.
-	enum class Mode {
-		Portable,    /// Binary absent or detection failed; config lives in the project dir.
-		Local,       /// Binary detected, interactive mode OFF.
-		Interactive  /// Binary detected, interactive mode ON.
+	/// Where the current project's root config lives — resolved from disk at project selection.
+	enum class ConfigSource {
+		Project, /// Embedded in the project directory (portable project).
+		System   /// The daemon-reported system config path.
 	};
 
 	/// UI theme preference.
@@ -77,7 +80,6 @@ public:
 	/**
 	 * Replaces persistent settings with sanitized values from SettingsFile.
 	 * Missing keys receive hard-coded defaults. Unknown keys are ignored.
-	 * Recomputes currentMode after loading.
 	 */
 	void load(const Values& source) noexcept;
 
@@ -99,7 +101,7 @@ public:
 	 */
 	string getThemePath() const noexcept;
 
-	void setBinaryPath(const string& path)     noexcept; // Also recomputes currentMode.
+	void setBinaryPath(const string& path)     noexcept;
 	void setDataDir(const string& dir)         noexcept;
 	void setThemePath(const string& dir)       noexcept;
 	void setProjectsDir(const string& dir)     noexcept;
@@ -112,7 +114,7 @@ public:
 	bool shouldDebugFiles()         const noexcept { return is(DEBUG_FILES);          }
 	bool shouldDebugHardwareTest()  const noexcept { return is(DEBUG_HARDWARE_TEST);  }
 
-	void setInteractiveMode(bool value)    noexcept; // Also recomputes currentMode.
+	void setInteractiveMode(bool value)    noexcept;
 	void setPreserveEmptyDir(bool value)   noexcept;
 	void setRemoveInvalidItems(bool value) noexcept;
 	void setSaveBackup(bool value)         noexcept;
@@ -149,20 +151,33 @@ public:
 	ThemeStyle getThemeStyle()           const noexcept;
 	void       setThemeStyle(ThemeStyle) noexcept;
 
-	Mode getMode()      const noexcept  { return currentMode;                      }
-	bool isPortable()   const noexcept  { return currentMode == Mode::Portable;    }
-	bool isLocal()      const noexcept  { return currentMode == Mode::Local;       }
-	bool isInteractive() const noexcept { return currentMode == Mode::Interactive; }
+	/**
+	 * @return true when a daemon is configured
+	 */
+	bool hasBinary() const noexcept { return not getValue(PATH_BINARY).empty(); }
 
 	/**
-	 * @param mode
-	 * @return the two main modes, sorted by the passed mode.
+	 * @return true when live testing against the daemon is enabled.
 	 */
-	static std::pair<string, string> getModeLabels(Mode mode) noexcept {
-		// Local and Interactive share the non-portable "Local" label.
-		if (mode == Mode::Portable) return {"Portable", "Local"};
-		return {"Local", "Portable"};
-	}
+	bool isInteractive() const noexcept { return hasBinary() and is(INTERACTIVE_MODE); }
+
+	ConfigSource getConfigSource() const noexcept { return configSource; }
+	void setConfigSource(ConfigSource source) noexcept { configSource = source; }
+
+	/**
+	 * Whether the system config exists or can be created there; always false
+	 * without a binary (empty system path).
+	 * @return true when it is available.
+	 */
+	bool isSystemConfigAvailable() const noexcept;
+
+	/**
+	 * Tests write access to path, or to its closest existing ancestor when it
+	 * does not exist yet.
+	 * @param path
+	 * @return true when writable; false for an empty path.
+	 */
+	static bool isPathWritable(const string& path) noexcept;
 
 	/**
 	 * Runtime flag: the staged config no longer matches the live data and must be redeployed.
@@ -178,7 +193,7 @@ public:
 	bool getHasControls() const noexcept { return hasControls; }
 
 	void setConfigPath(const string& path)     noexcept;
-	void setCurrentProject(const string& name) noexcept; // Also writes DEFAULT_PROJECT.
+	void setCurrentProject(const string& name) noexcept; // Also writes DEFAULT_PROJECT and resolves ConfigSource.
 	void setColorFiles(StringVector files)     noexcept; // Also calls colorFilesChanged if set.
 
 	/**
@@ -190,18 +205,38 @@ public:
 	void setDataDirStatus(bool gameData, bool colors, bool controls) noexcept;
 
 	/**
-	 * projectsDir + currentProject + "/", or empty if either is unset.
+	 * projectsDir + name + "/", or empty if either is unset.
+	 * @param name project directory name.
 	 */
-	string getProjectDir() const noexcept;
+	string getProjectDir(const string& name) const noexcept;
 
 	/**
-	 * Portable: getProjectDir() + CONFIG_FILE.  Local/Interactive: configPath.
+	 * Same for the current project.
+	 */
+	string getProjectDir() const noexcept { return getProjectDir(currentProject); }
+
+	/**
+	 * ConfigSource::Project: getProjectDir() + CONFIG_FILE.  System: configPath.
 	 */
 	string getActiveConfigPath() const noexcept;
 
+	/**
+	 * Write access to the active root config target; project-sourced configs
+	 * delegate to the project directory.
+	 * @return true when it can be written or created.
+	 */
+	bool isRootConfigWritable() const noexcept;
+
+	/**
+	 * Write access to the current project directory.
+	 * @return true when it can be written or created; false with no project.
+	 */
+	bool isProjectDirWritable() const noexcept;
+
 protected:
 
-	Mode currentMode = Mode::Portable;
+	/// Root config location for the current project; System when no project is selected.
+	ConfigSource configSource = ConfigSource::System;
 
 	/// True when the staged config needs a refresh to match edited data.
 	bool configDirty = false;
@@ -228,9 +263,12 @@ private:
 	static Settings instance;
 
 	/**
-	 * Derives currentMode from binaryPath (empty → Portable) and interactiveMode.
+	 * Resolves configSource for the current project from disk:
+	 * an embedded config file wins; otherwise the system config is used when it
+	 * exists or can be created, falling back to the project directory.
+	 * An empty system path (no binary) is never writable, so it falls through.
 	 */
-	void updateMode() noexcept;
+	void resolveConfigSource() noexcept;
 };
 
 } // namespace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,8 @@ set(COMMON_SRCS
 set(STORAGE_SRCS
 	${CMAKE_SOURCE_DIR}/src/Ui/Storage/Data.cpp
 	${CMAKE_SOURCE_DIR}/src/Ui/Storage/BoxButton.cpp
+	# BoxButtonCollection reads the writability state when populating.
+	${CMAKE_SOURCE_DIR}/src/config/Settings.cpp
 	${CMAKE_SOURCE_DIR}/src/Ui/Storage/BoxButtonCollection.cpp
 )
 

--- a/tests/config/SettingsFileTest.cpp
+++ b/tests/config/SettingsFileTest.cpp
@@ -52,7 +52,7 @@ TEST_F(SettingsFileTest, MissingFile) {
 	EXPECT_FALSE(SettingsFile::initialize());
 	const auto& s = Settings::get();
 	EXPECT_TRUE(s.getBinaryPath().empty());
-	EXPECT_TRUE(s.isPortable());
+	EXPECT_FALSE(s.hasBinary());
 	EXPECT_TRUE(s.shouldSaveBackup());
 	EXPECT_FALSE(s.shouldDebugFiles());
 }

--- a/tests/config/SettingsTest.cpp
+++ b/tests/config/SettingsTest.cpp
@@ -20,12 +20,14 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <filesystem>
+#include <fstream>
+#include <unistd.h>
 #include <gtest/gtest.h>
 #include "config/Settings.hpp"
 
 using namespace LEDSpicerUI;
 using namespace LEDSpicerUI::Config;
-using Mode       = Settings::Mode;
 using ThemeStyle = Settings::ThemeStyle;
 
 class SettingsTest : public ::testing::Test {
@@ -52,8 +54,7 @@ TEST_F(SettingsTest, DefaultState) {
 	EXPECT_FALSE(s.shouldDebugFiles());
 	EXPECT_EQ(0, s.getLayoutGrid());
 	EXPECT_EQ(1500u, s.getLayoutTestTimeout());
-	EXPECT_EQ(Mode::Portable, s.getMode());
-	EXPECT_TRUE(s.isPortable());
+	EXPECT_FALSE(s.hasBinary());
 }
 
 TEST_F(SettingsTest, LoadAndSerialize) {
@@ -85,7 +86,7 @@ TEST_F(SettingsTest, LoadAndSerialize) {
 	EXPECT_TRUE (s.shouldDebugFiles());
 	EXPECT_EQ(30, s.getLayoutGrid());
 	EXPECT_EQ(2500u, s.getLayoutTestTimeout());
-	EXPECT_EQ(Mode::Local, s.getMode());
+	EXPECT_TRUE(s.hasBinary());
 
 	// Round-trip: snapshot → reset → load → same values.
 	const Values snap(s.begin(), s.end());
@@ -95,7 +96,6 @@ TEST_F(SettingsTest, LoadAndSerialize) {
 	EXPECT_EQ(ThemeStyle::Dark,      s.getThemeStyle());
 	EXPECT_EQ(30,                    s.getLayoutGrid());
 	EXPECT_EQ(2500u,                 s.getLayoutTestTimeout());
-	EXPECT_EQ(Mode::Local,           s.getMode());
 }
 
 TEST_F(SettingsTest, LoadFillsMissingKeysWithDefaults) {
@@ -107,31 +107,8 @@ TEST_F(SettingsTest, LoadFillsMissingKeysWithDefaults) {
 	EXPECT_EQ(ThemeStyle::Light, s.getThemeStyle());
 	EXPECT_TRUE(s.shouldSaveBackup());     // missing → default True
 	EXPECT_FALSE(s.shouldDebugFiles());    // missing → default False
-	// interactive mode defaults to True → with binary set, mode is Interactive
-	EXPECT_EQ(Mode::Interactive, s.getMode());
-}
-
-TEST_F(SettingsTest, ModeDerivation) {
-	auto& s = Settings::get();
-
-	// No binary → Portable regardless of interactive preference.
-	s.setBinaryPath("");
-	s.setInteractiveMode(true);
-	EXPECT_EQ(Mode::Portable, s.getMode());
-	EXPECT_TRUE(s.isPortable());
-
-	// Binary + interactive → Interactive.
-	s.setBinaryPath("/usr/bin/ledspicerd");
-	EXPECT_EQ(Mode::Interactive, s.getMode());
+	// interactive mode defaults to True → with binary set, testing is enabled
 	EXPECT_TRUE(s.isInteractive());
-
-	// Binary, interactive off → Local.
-	s.setInteractiveMode(false);
-	EXPECT_EQ(Mode::Local, s.getMode());
-
-	// Clear binary → Portable again.
-	s.setBinaryPath("");
-	EXPECT_EQ(Mode::Portable, s.getMode());
 }
 
 TEST_F(SettingsTest, VolatileState) {
@@ -145,16 +122,6 @@ TEST_F(SettingsTest, VolatileState) {
 	EXPECT_EQ("arcade", s.getCurrentProject());
 	EXPECT_EQ("arcade", s.getDefaultProject()); // setCurrentProject also writes DEFAULT_PROJECT
 	EXPECT_EQ("/home/user/projects/arcade/", s.getProjectDir());
-
-	// Portable mode → active config is inside the project dir.
-	EXPECT_TRUE(s.isPortable());
-	EXPECT_EQ("/home/user/projects/arcade/" CONFIG_FILE, s.getActiveConfigPath());
-
-	// Local mode → active config is configPath.
-	s.setBinaryPath("/usr/bin/ledspicerd");
-	s.setInteractiveMode(false);
-	EXPECT_TRUE(s.isLocal());
-	EXPECT_EQ("/etc/ledspicer/ledspicer.conf", s.getActiveConfigPath());
 
 	StringVector files = {"colors.ini", "extra.ini"};
 	s.setColorFiles(files);
@@ -229,6 +196,125 @@ TEST_F(SettingsTest, LayoutTestTimeoutConversion) {
 	s.load(Values{});
 	s.load(snap);
 	EXPECT_EQ(500u, s.getLayoutTestTimeout());
+}
+
+TEST_F(SettingsTest, Writability) {
+	namespace fs = std::filesystem;
+	auto& s = Settings::get();
+
+	// Volatile state survives load(); reset it so this test is order-independent.
+	s.setConfigPath("");
+	s.setCurrentProject("");
+
+	// Nothing configured → nothing writable.
+	EXPECT_FALSE(s.isProjectDirWritable());
+	EXPECT_FALSE(s.isRootConfigWritable());
+
+	const string base {::testing::TempDir() + "settingsWritability/"};
+	fs::create_directories(base + "projects/arcade");
+
+	// No system config anywhere → the config lives inside the project.
+	s.setProjectsDir(base + "projects/");
+	s.setCurrentProject("arcade");
+	EXPECT_TRUE(s.isProjectDirWritable());
+	EXPECT_EQ(Settings::ConfigSource::Project, s.getConfigSource());
+	EXPECT_TRUE(s.isRootConfigWritable());
+
+	// Missing project dir → probes the closest existing ancestor.
+	s.setCurrentProject("brandNew");
+	EXPECT_TRUE(s.isProjectDirWritable());
+
+	// Creatable system config → System source; missing file probes its directory.
+	s.setConfigPath(base + "ledspicer.conf");
+	s.setCurrentProject("brandNew");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+	EXPECT_TRUE(s.isRootConfigWritable());
+
+	// Permission bits are bypassed by root, so the negative case only runs unprivileged.
+	if (geteuid() != 0) {
+		fs::create_directories(base + "locked");
+		std::ofstream(base + "locked/" CONFIG_FILE) << "";
+		fs::permissions(base + "locked/" CONFIG_FILE, fs::perms::owner_read);
+		s.setConfigPath(base + "locked/" CONFIG_FILE);
+		s.setCurrentProject("brandNew");
+		// An existing read-only system config stays the source, locked.
+		EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+		EXPECT_FALSE(s.isRootConfigWritable());
+		fs::permissions(base + "locked/" CONFIG_FILE, fs::perms::owner_all);
+	}
+
+	fs::remove_all(base);
+}
+
+TEST_F(SettingsTest, ConfigSourceResolution) {
+	namespace fs = std::filesystem;
+	auto& s = Settings::get();
+
+	const string base {::testing::TempDir() + "settingsConfigSource/"};
+	fs::create_directories(base + "projects/existing");
+	s.setProjectsDir(base + "projects/");
+
+	// No project selected → System.
+	s.setConfigPath("");
+	s.setCurrentProject("");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+
+	// No binary (empty system path) → the config lives inside the project.
+	s.setCurrentProject("existing");
+	EXPECT_EQ(Settings::ConfigSource::Project, s.getConfigSource());
+
+	// No config anywhere, system location writable → System.
+	s.setConfigPath(base + CONFIG_FILE);
+	s.setCurrentProject("existing");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+
+	// Same resolution when the project directory does not exist yet.
+	s.setCurrentProject("brandNew");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+
+	// An existing system config wins over creation logic, for both
+	// existing and not-yet-created projects.
+	std::ofstream(base + CONFIG_FILE) << "";
+	s.setCurrentProject("existing");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+	s.setCurrentProject("brandNew");
+	EXPECT_EQ(Settings::ConfigSource::System, s.getConfigSource());
+
+	// An embedded config wins even when the system config exists.
+	std::ofstream(base + "projects/existing/" CONFIG_FILE) << "";
+	s.setCurrentProject("existing");
+	EXPECT_EQ(Settings::ConfigSource::Project, s.getConfigSource());
+
+	// No config anywhere and a read-only system location → Project.
+	// Permission bits are bypassed by root, so this only runs unprivileged.
+	if (geteuid() != 0) {
+		fs::create_directories(base + "locked");
+		fs::permissions(base + "locked", fs::perms::owner_read | fs::perms::owner_exec);
+		s.setConfigPath(base + "locked/" CONFIG_FILE);
+		s.setCurrentProject("brandNew");
+		EXPECT_EQ(Settings::ConfigSource::Project, s.getConfigSource());
+		fs::permissions(base + "locked", fs::perms::owner_all);
+	}
+
+	fs::remove_all(base);
+}
+
+TEST_F(SettingsTest, BinaryAndInteractive) {
+	auto& s = Settings::get();
+
+	// Preference without a binary never enables testing.
+	s.setBinaryPath("");
+	s.setInteractiveMode(true);
+	EXPECT_FALSE(s.hasBinary());
+	EXPECT_FALSE(s.isInteractive());
+
+	s.setBinaryPath("/usr/bin/ledspicerd");
+	EXPECT_TRUE(s.hasBinary());
+	EXPECT_TRUE(s.isInteractive());
+
+	// Binary without the preference: testable machine, testing declined.
+	s.setInteractiveMode(false);
+	EXPECT_FALSE(s.isInteractive());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Task-Url: https://github.com/meduzapat/LEDSpicerUI/issues/90

- Settings: replace global Portable/Local/Interactive mode with per-project ConfigSource (embedded config → Project, else System) resolved from disk at project selection; add hasBinary(), isRootConfigWritable(), isProjectDirWritable(),
isSystemConfigAvailable(), isPathWritable(). Remove mode-mismatch guards: opening always reads the correct config location.

- Read-only lock-down: widgets carrying RoLockedConfig/RoLockedProject Glade markers desensitize (or flip edit→view) via
Defaults::applyWritability, swept over toplevels and re-applied per item on display. Save skips a read-only source after confirmation; partial saves reported on the status bar.

- Path choosers freeze while the project is dirty; a binary change reloads the open project.

- Project dialog: portable toggle for new projects, config-location conversions (make portable / deploy to system / use system config), subtitle shows the source and a lock marker when read-only.